### PR TITLE
Fix layout wrapping bug

### DIFF
--- a/MyToybox/Sources/Screens/Root/RootScreen.swift
+++ b/MyToybox/Sources/Screens/Root/RootScreen.swift
@@ -41,7 +41,7 @@ extension RootScreen {
     /// The sidebar view that displays a list of available screens.
     @ViewBuilder
     fileprivate func sidebarView() -> some View {
-        List(viewModel.filterdScreens(), selection: $selection) { screen in
+        List(viewModel.filteredScreens(), selection: $selection) { screen in
             NavigationLink(value: screen) {
                 VStack(alignment: .leading) {
                     Text(screen.title)
@@ -78,7 +78,7 @@ extension RootScreen {
             }
             .navigationTitle(selection?.title ?? "")
             .toolbar {
-                Button("Sorce Code", systemImage: "safari") {
+                Button("Source Code", systemImage: "safari") {
                     if let url = selection?.html {
                         openURL(url)
                     }

--- a/MyToybox/Sources/Screens/Root/RootScreenViewModel.swift
+++ b/MyToybox/Sources/Screens/Root/RootScreenViewModel.swift
@@ -31,7 +31,7 @@ final class RootScreenViewModel {
     /// Returns screens that match any of the selected tags.
     ///
     /// - If no tags are selected, returns all screens.
-    func filterdScreens() -> [Screen] {
+    func filteredScreens() -> [Screen] {
         // Build a set of selected tags
         let selectedTags = Set(tags.selections.filter(\.isSelected).map(\.tag))
         // Return all if no selection

--- a/MyToybox/Sources/Screens/TagPicker/PickerFlowLayout.swift
+++ b/MyToybox/Sources/Screens/TagPicker/PickerFlowLayout.swift
@@ -113,15 +113,18 @@ struct PickerFlowLayout: Layout {
 
             for (index, subview) in zip(subviews.indices, subviews) {
                 let size = subview.sizeThatFits(.unspecified)
-                let widthWithSpacing = size.width + spacingBefore(index: index)
+                var spacingBeforeCurrent = spacingBefore(index: index)
+                var widthWithSpacing = size.width + spacingBeforeCurrent
 
                 // If this item doesn't fit, finalize the current row
                 if index != 0 && widthWithSpacing > remainingWidth {
                     finalizeRow(at: index - 1)
+                    spacingBeforeCurrent = spacingBefore(index: index)
+                    widthWithSpacing = size.width + spacingBeforeCurrent
                 }
 
                 // Add to current row
-                xOffsets.append(maxPossibleWidth - remainingWidth + spacingBefore(index: index))
+                xOffsets.append(maxPossibleWidth - remainingWidth + spacingBeforeCurrent)
                 remainingWidth -= widthWithSpacing
                 rowHeight = max(rowHeight, size.height)
                 itemsInRow += 1


### PR DESCRIPTION
## Summary
- adjust `PickerFlowLayout` to properly handle wrapping to a new row
- correct typo in `RootScreenViewModel` and use `filteredScreens()`
- fix "Source Code" button label

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686a105524fc832c94137693c7b90b64