### PR TITLE
Refactor Lost Row fetch and improve ColorCircleView state management

### DIFF
--- a/Packages/Sources/MyToyboxScreens/Screens/ColorHexAnimation/ColorHexAnimationScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ColorHexAnimation/ColorHexAnimationScreen.swift
@@ -41,7 +41,7 @@ struct ColorCircleView: View, @MainActor Animatable {
     /// The color to display and animate.
     var color: Color
     var environment: EnvironmentValues
-    @State var fontSizde: CGFloat = 30
+    @State private var fontSizde: CGFloat = 30
 
     // Animate by interpolating the resolved color's components
     var animatableData: Color.Resolved.AnimatableData {

--- a/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/LostRowAnimationScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/LostRowAnimationScreen.swift
@@ -32,7 +32,7 @@ struct LostRowAnimationScreen: View {
         }
     }
 
-    func fetch() async {
+    func fetch() {
         show = false
         Task.detached {
             try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/Thumbnail.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/Thumbnail.swift
@@ -39,7 +39,7 @@ extension LostRowAnimationScreen {
             }
         }
 
-        func fetch() async {
+        func fetch() {
             show = false
             Task.detached {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/Packages/Sources/MyToyboxScreens/Screens/StableFluid/MetalStableFluidView.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/StableFluid/MetalStableFluidView.swift
@@ -484,9 +484,11 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
                     scalingMode: viewModel.imageContentMode.metalScalingMode
                 )
                 enc.setFragmentBytes(&imageParams, length: MemoryLayout<ImageParamsBuffer>.stride, index: 0)
+
             case .ink:
                 enc.setRenderPipelineState(inkRenderPSO)
                 enc.setFragmentTexture(inkTex[inkIndex], index: 0)
+
             case .velocity:
                 enc.setRenderPipelineState(velRenderPSO)
                 enc.setFragmentTexture(velTex[velIndex], index: 0)


### PR DESCRIPTION
## Summary

- Remove redundant `async` from Lost Row `fetch()` helpers; scheduling still happens
  inside `Task.detached`, so the public API no longer implies awaiting.
- Tighten encapsulation on `ColorCircleView` by making font-related `@State` private.
- Minor whitespace-only formatting between Metal stable-fluid render-pass `switch`
  branches for readability (no shader or pipeline behavior change).

## Changes

- **`LostRowAnimationScreen.swift`**: `fetch()` is no longer `async` (logic unchanged;
  delay remains in `Task.detached`).
- **`Thumbnail.swift`**: Same `fetch()` signature alignment for the Lost Row thumbnail
  preview.
- **`ColorHexAnimationScreen.swift`**: `@State private var fontSizde` on `ColorCircleView`.
- **`MetalStableFluidView.swift`**: Insert blank lines between `.image`, `.ink`, and
  `.velocity` cases in the render-pass `switch`.

## Motivation & Context

- The previous `async` `fetch()` did not `await` asynchronous work at the end of the
  function; callers gained no real suspension benefit and the signature overstated
  async semantics. Synchronous `fetch()` plus `Task.detached` reflects actual
  behavior.
- `private` state constrains mutation to `ColorCircleView` and matches typical SwiftUI
  encapsulation for view-local `@State`.
- Metal changes are formatting-only; they make a long `switch` easier to scan during
  future edits.

## Screenshots

- Not applicable — no intended visual or behavioral change beyond the above API /
  readability tweaks.

## How to Test

1. **Lost Row Animation**: Open the screen and actions that call `fetch()`; confirm
   the delayed show/hide behavior still works as before.
2. **Color Hex Animation**: Confirm the color circle / hex label animation behaves as
   before.
3. **Stable Fluid** (optional smoke): Open the screen and confirm rendering still
   looks normal.

## Related Issues

- None

## Notes for Reviewers

- Very small diff (4 files); review focus: Lost Row `fetch()` call sites do not need
  `await` anymore — verify no remaining call sites expect `async` only in unmerged
  work.
- No shader or Metal pipeline logic was modified in `MetalStableFluidView.swift`.

## Changelog

- refactor(swiftui): simplify Lost Row fetch and narrow view state