### PR TITLE
Refactor Lost Row fetch calls to use synchronous fetch

### DIFF
--- a/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/LostRowAnimationScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/LostRowAnimationScreen.swift
@@ -25,10 +25,10 @@ struct LostRowAnimationScreen: View {
         }
         .scrollIndicators(.hidden)
         .task {
-            await fetch()
+            fetch()
         }
         .refreshable {
-            await fetch()
+            fetch()
         }
     }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/Thumbnail.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/LostRowAnimation/Thumbnail.swift
@@ -35,7 +35,7 @@ extension LostRowAnimationScreen {
                 self.refreshID = refreshID
             }
             .task(id: refreshID) {
-                await fetch()
+                fetch()
             }
         }
 


### PR DESCRIPTION
## Summary

- Remove `await` from Lost Row `fetch()` call sites so they match the synchronous
  `fetch()` API introduced in the earlier refactor (PR #119).
- Scope is limited to `.task` / `.refreshable` on the main screen and `.task(id:)`
  in the sidebar thumbnail preview — no logic changes inside `fetch()` itself.

## Changes

- **`LostRowAnimationScreen.swift`**: Drop `await` in the root `.task` and
  `.refreshable` closures that invoke `fetch()`.
- **`Thumbnail.swift`**: Drop `await` in the thumbnail preview’s `.task(id:)` closure.

## Motivation & Context

- After `fetch()` became non-`async`, leaving `await fetch()` at call sites is
  inconsistent with the actual signature and can produce compiler warnings or
  confusion about suspension. This commit completes the API alignment for Lost Row
  only.

## Screenshots

- Not applicable — call-site-only change; expected runtime behavior is unchanged.

## How to Test

1. Open **Lost Row Animation** from the sidebar; confirm initial load and pull-to-
   refresh still behave as before (delayed show/hide via `Task.detached`).
2. Confirm the **Lost Row** thumbnail in the list still updates when the preview
   refreshes.

## Notes for Reviewers

- Single commit, 2 files, ±3 lines — quick review.
- Complements **PR #119** (`refactor(swiftui): simplify Lost Row fetch…`); this PR
  only fixes callers that still used `await` after that change.

## Changelog

- refactor(swiftui): remove await from Lost Row fetch call sites