### PR TITLE
Optimize MSL shaders with threadgroup tiling and half precision

### DIFF
--- a/Packages/Sources/MyToyboxScreens/Screens/GameOfLife/MetalGameOfLifeView.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/GameOfLife/MetalGameOfLifeView.swift
@@ -32,7 +32,8 @@ struct MetalGameOfLifeView: PlatformAgnosticViewRepresentable {
         private let viewModel: GameOfLifeViewModel
         let device: any MTLDevice
         private let queue: any MTLCommandQueue
-        private var computePSO: (any MTLComputePipelineState)!
+        private var computePSOWrap: (any MTLComputePipelineState)!
+        private var computePSOClamp: (any MTLComputePipelineState)!
         private var renderPSO: (any MTLRenderPipelineState)!
         private var srcTex: (any MTLTexture)!
         private var dstTex: (any MTLTexture)!
@@ -61,19 +62,29 @@ struct MetalGameOfLifeView: PlatformAgnosticViewRepresentable {
         private func buildPipelines() {
             let library = try! device.makeDefaultLibrary(bundle: .module)
 
-            // Compute
-            let cs = library.makeFunction(name: "lifeStep")!
-            computePSO = try! device.makeComputePipelineState(function: cs)
+            // Compute – two variants via function constant (kWrap: bool at index 0)
+            func makeLifeStepPSO(wrap: Bool) -> any MTLComputePipelineState {
+                let fcv = MTLFunctionConstantValues()
+                var flag = wrap
+                fcv.setConstantValue(&flag, type: .bool, index: 0)
+                let fn = try! library.makeFunction(name: "lifeStep", constantValues: fcv)
+                let desc = MTLComputePipelineDescriptor()
+                desc.computeFunction = fn
+                desc.threadGroupSizeIsMultipleOfThreadExecutionWidth = true
+                return try! device.makeComputePipelineState(descriptor: desc, options: [], reflection: nil)
+            }
+            computePSOWrap = makeLifeStepPSO(wrap: true)
+            computePSOClamp = makeLifeStepPSO(wrap: false)
 
             // Render
             let vs = library.makeFunction(name: "fullscreenQuadVS")!
             let fs = library.makeFunction(name: "lifeBlitFS")!
 
-            let desc = MTLRenderPipelineDescriptor()
-            desc.vertexFunction = vs
-            desc.fragmentFunction = fs
-            desc.colorAttachments[0].pixelFormat = .bgra8Unorm
-            renderPSO = try! device.makeRenderPipelineState(descriptor: desc)
+            let rDesc = MTLRenderPipelineDescriptor()
+            rDesc.vertexFunction = vs
+            rDesc.fragmentFunction = fs
+            rDesc.colorAttachments[0].pixelFormat = .bgra8Unorm
+            renderPSO = try! device.makeRenderPipelineState(descriptor: rDesc)
         }
 
         /// 指定サイズでピンポン用テクスチャを生成し、乱数初期化する。
@@ -146,21 +157,19 @@ struct MetalGameOfLifeView: PlatformAgnosticViewRepresentable {
         /// ライフゲームの 1 ステップを計算するコンピュートパスをエンコードする。
         private func encodeCompute(into cb: any MTLCommandBuffer) {
             guard let enc = cb.makeComputeCommandEncoder() else { return }
-            enc.setComputePipelineState(computePSO)
+
+            let pso = computePSOWrap!
+            enc.setComputePipelineState(pso)
             enc.setTexture(srcTex, index: 0)
             enc.setTexture(dstTex, index: 1)
 
             var wh1 = SIMD3<UInt32>(UInt32(srcTex.width), UInt32(srcTex.height), 1)
-            var wrap: UInt32 = 1 // 1 にするとトーラス（ラップ）境界
             enc.setBytes(&wh1, length: MemoryLayout<SIMD3<UInt32>>.stride, index: 0)
-            enc.setBytes(&wrap, length: MemoryLayout<UInt32>.stride, index: 1)
 
-            let w = computePSO.threadExecutionWidth
-            let h = max(1, computePSO.maxTotalThreadsPerThreadgroup / w)
-            let tg = MTLSize(width: w, height: h, depth: 1)
+            let tg = MTLSize(width: 16, height: 16, depth: 1)
             let ng = MTLSize(
-                width: (srcTex.width + w - 1) / w,
-                height: (srcTex.height + h - 1) / h,
+                width: (srcTex.width + 15) / 16,
+                height: (srcTex.height + 15) / 16,
                 depth: 1
             )
             enc.dispatchThreadgroups(ng, threadsPerThreadgroup: tg)

--- a/Packages/Sources/MyToyboxScreens/Screens/GameOfLife/MetalGameOfLifeView.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/GameOfLife/MetalGameOfLifeView.swift
@@ -32,8 +32,7 @@ struct MetalGameOfLifeView: PlatformAgnosticViewRepresentable {
         private let viewModel: GameOfLifeViewModel
         let device: any MTLDevice
         private let queue: any MTLCommandQueue
-        private var computePSOWrap: (any MTLComputePipelineState)!
-        private var computePSOClamp: (any MTLComputePipelineState)!
+        private var computePSO: (any MTLComputePipelineState)!
         private var renderPSO: (any MTLRenderPipelineState)!
         private var srcTex: (any MTLTexture)!
         private var dstTex: (any MTLTexture)!
@@ -62,19 +61,15 @@ struct MetalGameOfLifeView: PlatformAgnosticViewRepresentable {
         private func buildPipelines() {
             let library = try! device.makeDefaultLibrary(bundle: .module)
 
-            // Compute – two variants via function constant (kWrap: bool at index 0)
-            func makeLifeStepPSO(wrap: Bool) -> any MTLComputePipelineState {
-                let fcv = MTLFunctionConstantValues()
-                var flag = wrap
-                fcv.setConstantValue(&flag, type: .bool, index: 0)
-                let fn = try! library.makeFunction(name: "lifeStep", constantValues: fcv)
-                let desc = MTLComputePipelineDescriptor()
-                desc.computeFunction = fn
-                desc.threadGroupSizeIsMultipleOfThreadExecutionWidth = true
-                return try! device.makeComputePipelineState(descriptor: desc, options: [], reflection: nil)
-            }
-            computePSOWrap = makeLifeStepPSO(wrap: true)
-            computePSOClamp = makeLifeStepPSO(wrap: false)
+            // Compute – torus (wrap) boundary via function constant kWrap=true at index 0
+            let fcv = MTLFunctionConstantValues()
+            var wrap = true
+            fcv.setConstantValue(&wrap, type: .bool, index: 0)
+            let lifeFn = try! library.makeFunction(name: "lifeStep", constantValues: fcv)
+            let cDesc = MTLComputePipelineDescriptor()
+            cDesc.computeFunction = lifeFn
+            cDesc.threadGroupSizeIsMultipleOfThreadExecutionWidth = true
+            computePSO = try! device.makeComputePipelineState(descriptor: cDesc, options: [], reflection: nil)
 
             // Render
             let vs = library.makeFunction(name: "fullscreenQuadVS")!
@@ -158,8 +153,7 @@ struct MetalGameOfLifeView: PlatformAgnosticViewRepresentable {
         private func encodeCompute(into cb: any MTLCommandBuffer) {
             guard let enc = cb.makeComputeCommandEncoder() else { return }
 
-            let pso = computePSOWrap!
-            enc.setComputePipelineState(pso)
+            enc.setComputePipelineState(computePSO)
             enc.setTexture(srcTex, index: 0)
             enc.setTexture(dstTex, index: 1)
 

--- a/Packages/Sources/MyToyboxScreens/Screens/ProgressiveBlur/ProgressiveBlurScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ProgressiveBlur/ProgressiveBlurScreen.swift
@@ -32,24 +32,25 @@ struct ProgressiveBlurScreen: View {
 /// A custom view modifier that applies a progressive Gaussian blur
 /// using a Metal shader. The blur radius can be dynamically adjusted.
 ///
-/// The shader will blur the image more toward the bottom of the view.
+/// Uses two separable 1D passes (horizontal then vertical) for O(r)+O(r)
+/// performance instead of the O(r^2) cost of a single 2D convolution.
 struct ProgressiveBlur: ViewModifier {
     /// The base blur radius applied in the shader.
     let radius: Double
 
     func body(content: Content) -> some View {
-        // Define the maximum sampling offset needed based on blur radius.
         let offset = CGSize(width: radius, height: radius)
 
-        // Load and configure the shader function.
-        let function = ShaderFunction(
+        let fn = ShaderFunction(
             library: .module,
-            name: "ProgressiveBlur::main"
+            name: "ProgressiveBlur::progressiveBlur1D"
         )
-        let shader = function(.boundingRect, .float(radius))
+        let horizontal = fn(.boundingRect, .float(radius), .float(0))
+        let vertical   = fn(.boundingRect, .float(radius), .float(1))
 
-        // Apply the shader as a layer effect.
-        content.layerEffect(shader, maxSampleOffset: offset)
+        content
+            .layerEffect(horizontal, maxSampleOffset: offset)
+            .layerEffect(vertical, maxSampleOffset: offset)
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/ProgressiveBlur/ProgressiveBlurScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ProgressiveBlur/ProgressiveBlurScreen.swift
@@ -5,7 +5,8 @@ import SwiftUI
 /// A view that continuously animates a blur effect across a static image.
 ///
 /// The blur radius changes over time using a sine wave,
-/// and the effect is rendered using a custom Metal shader (`ProgressiveBlur::main`).
+/// and the effect is rendered with `ProgressiveBlur::progressiveBlur1D` applied twice
+/// (horizontal then vertical) via chained `.layerEffect` calls.
 @Metadata(title: "Progressive Blur", description: "ProgressiveBlur", tags: [.metal])
 struct ProgressiveBlurScreen: View {
     /// The reference start time of the animation.

--- a/Packages/Sources/MyToyboxScreens/Screens/StableFluid/MetalStableFluidView.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/StableFluid/MetalStableFluidView.swift
@@ -88,10 +88,6 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
             /// Background image aspect ratio (`width / height`).
             /// 背景画像アスペクト比（`幅 / 高さ`）。
             var imageAspect: Float
-
-            /// `0` = aspect fit, `1` = aspect fill; must match MSL `ImageParams.scalingMode`.
-            /// `0` = アスペクトフィット、`1` = アスペクトフィル。MSL `ImageParams.scalingMode` と一致させる。
-            var scalingMode: UInt32
         }
 
         // MARK: Brush Defaults
@@ -133,7 +129,8 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
         // -- Render pipeline state objects (one per display mode) --
         private var inkRenderPSO: (any MTLRenderPipelineState)!
         private var velRenderPSO: (any MTLRenderPipelineState)!
-        private var imageRenderPSO: (any MTLRenderPipelineState)!
+        private var imageFitRenderPSO: (any MTLRenderPipelineState)!
+        private var imageFillRenderPSO: (any MTLRenderPipelineState)!
 
         /// Background image texture for the image-distortion display mode.
         /// 画像歪み表示モード用の背景画像テクスチャ。
@@ -171,6 +168,10 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
         /// Temporary texture storing the divergence of the velocity field.
         /// 速度場の発散を格納する一時テクスチャ。
         private var divergenceTex: (any MTLTexture)!
+
+        /// Heap used for all simulation textures.
+        /// シミュレーションテクスチャに使う MTLHeap。
+        private var simulationHeap: (any MTLHeap)?
 
         private var velIndex = 0
         private var inkIndex = 0
@@ -214,7 +215,10 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
 
             func computePSO(_ name: String) -> any MTLComputePipelineState {
                 let fn = library.makeFunction(name: name)!
-                return try! device.makeComputePipelineState(function: fn)
+                let desc = MTLComputePipelineDescriptor()
+                desc.computeFunction = fn
+                desc.threadGroupSizeIsMultipleOfThreadExecutionWidth = true
+                return try! device.makeComputePipelineState(descriptor: desc, options: [], reflection: nil)
             }
 
             brushPSO = computePSO("fluidBrush")
@@ -240,7 +244,20 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
 
             inkRenderPSO = renderPSO("fluidInkFS")
             velRenderPSO = renderPSO("fluidVelocityFS")
-            imageRenderPSO = renderPSO("fluidImageFS")
+
+            func imageRenderPSO(fill: Bool) -> any MTLRenderPipelineState {
+                let fcv = MTLFunctionConstantValues()
+                var flag = fill
+                fcv.setConstantValue(&flag, type: .bool, index: 0)
+                let fs = try! library.makeFunction(name: "fluidImageFS", constantValues: fcv)
+                let desc = MTLRenderPipelineDescriptor()
+                desc.vertexFunction = vs
+                desc.fragmentFunction = fs
+                desc.colorAttachments[0].pixelFormat = .bgra8Unorm
+                return try! device.makeRenderPipelineState(descriptor: desc)
+            }
+            imageFitRenderPSO = imageRenderPSO(fill: false)
+            imageFillRenderPSO = imageRenderPSO(fill: true)
         }
 
         /// Load the "waterwheel" image from the asset catalog into a Metal texture.
@@ -276,23 +293,43 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
         /// - Parameter size: Number of cells along each axis.
         ///                   各軸のセル数。
         private func makeTextures(size: Int) {
-            func makeSimTexture() -> any MTLTexture {
-                let desc = MTLTextureDescriptor.texture2DDescriptor(
-                    pixelFormat: .rgba16Float,
-                    width: size,
-                    height: size,
-                    mipmapped: false
-                )
-                desc.usage = [.shaderRead, .shaderWrite]
-                return device.makeTexture(descriptor: desc)!
-            }
+            let texDesc = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .rgba16Float,
+                width: size,
+                height: size,
+                mipmapped: false
+            )
+            texDesc.usage = [.shaderRead, .shaderWrite]
+            texDesc.storageMode = .private
 
-            velTex = [makeSimTexture(), makeSimTexture()]
-            inkTex = [makeSimTexture(), makeSimTexture()]
-            pressureTex = [makeSimTexture(), makeSimTexture()]
-            forceTex = makeSimTexture()
-            newInkTex = makeSimTexture()
-            divergenceTex = makeSimTexture()
+            let texCount = 9 // vel×2 + ink×2 + pressure×2 + force + newInk + divergence
+            let sizeAndAlign = device.heapTextureSizeAndAlign(descriptor: texDesc)
+            let alignedSize = (sizeAndAlign.size + sizeAndAlign.align - 1) & ~(sizeAndAlign.align - 1)
+
+            let heapDesc = MTLHeapDescriptor()
+            heapDesc.size = alignedSize * texCount
+            heapDesc.storageMode = .private
+            heapDesc.hazardTrackingMode = .tracked
+
+            if let heap = device.makeHeap(descriptor: heapDesc) {
+                simulationHeap = heap
+                func heapTexture() -> any MTLTexture { heap.makeTexture(descriptor: texDesc)! }
+                velTex = [heapTexture(), heapTexture()]
+                inkTex = [heapTexture(), heapTexture()]
+                pressureTex = [heapTexture(), heapTexture()]
+                forceTex = heapTexture()
+                newInkTex = heapTexture()
+                divergenceTex = heapTexture()
+            } else {
+                simulationHeap = nil
+                func deviceTexture() -> any MTLTexture { device.makeTexture(descriptor: texDesc)! }
+                velTex = [deviceTexture(), deviceTexture()]
+                inkTex = [deviceTexture(), deviceTexture()]
+                pressureTex = [deviceTexture(), deviceTexture()]
+                forceTex = deviceTexture()
+                newInkTex = deviceTexture()
+                divergenceTex = deviceTexture()
+            }
 
             velIndex = 0
             inkIndex = 0
@@ -473,15 +510,16 @@ struct MetalStableFluidView: PlatformAgnosticViewRepresentable {
 
             switch viewModel.displayMode {
             case .image:
-                enc.setRenderPipelineState(imageRenderPSO)
+                let pso = viewModel.imageContentMode == .aspectFill
+                    ? imageFillRenderPSO! : imageFitRenderPSO!
+                enc.setRenderPipelineState(pso)
                 enc.setFragmentTexture(inkTex[inkIndex], index: 0)
                 enc.setFragmentTexture(backgroundTex, index: 1)
                 let bgW = Float(backgroundTex?.width ?? 1)
                 let bgH = Float(backgroundTex?.height ?? 1)
                 var imageParams = ImageParamsBuffer(
                     pixelStep: 1.0 / Float(velTex[0].width),
-                    imageAspect: bgW / bgH,
-                    scalingMode: viewModel.imageContentMode.metalScalingMode
+                    imageAspect: bgW / bgH
                 )
                 enc.setFragmentBytes(&imageParams, length: MemoryLayout<ImageParamsBuffer>.stride, index: 0)
 

--- a/Packages/Sources/MyToyboxScreens/Screens/StableFluid/StableFluidViewModel.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/StableFluid/StableFluidViewModel.swift
@@ -32,14 +32,6 @@ enum StableFluidImageContentMode: String, CaseIterable {
     /// 中央クロップ：正方形を隙間なく覆い、はみ出しを切り捨てる。
     case aspectFill
 
-    /// Value for `ImageParams.scalingMode` in MSL (`0` = fit, `1` = fill).
-    /// MSL の `ImageParams.scalingMode` 用（`0` = fit、`1` = fill）。
-    var metalScalingMode: UInt32 {
-        switch self {
-        case .aspectFit: 0
-        case .aspectFill: 1
-        }
-    }
 }
 
 // MARK: - BrushState

--- a/Packages/Sources/MyToyboxScreens/Shaders/GameOfLifeKernels.metal
+++ b/Packages/Sources/MyToyboxScreens/Shaders/GameOfLifeKernels.metal
@@ -2,64 +2,68 @@
 using namespace metal;
 
 // ============================================================================
-// Compute: 1 step of Game of Life
+// Compute: 1 step of Game of Life  (threadgroup-tiled, function-constant boundary)
 // ============================================================================
+
+/// Boundary mode selected at PSO creation time.
+/// true = torus (wrap-around), false = clamp.
+constant bool kWrap [[function_constant(0)]];
 
 /**
  * @brief   Perform a single step update of Conway's Game of Life.
  *
+ * Uses a 16x16 threadgroup with a 1-pixel halo (18x18 shared tile) to reduce
+ * global texture reads from 9 per cell to ~1 per cell.  The boundary mode
+ * (wrap / clamp) is resolved at compile time via `kWrap` function constant.
+ *
  * @param src   Source grid (R8Uint). Cell value is taken from .r & 1u.
  * @param dst   Destination grid (R8Uint).
  * @param wh1   Packed width (x), height (y), dummy (z).
- * @param wrap  Boundary mode. 0 = clamp, 1 = torus (wrap-around).
  * @param gid   Global thread position in the grid.
- * @param ltid  Local thread position in the threadgroup (unused).
- * @param gsize Total grid size in threads (unused).
- * @param lsize Threadgroup size (unused).
- *
- * The kernel reads the eight neighbors of each cell and writes the next state
- * according to the Game of Life rules:
- *  - Live cell survives with 2 or 3 neighbors.
- *  - Dead cell becomes live with exactly 3 neighbors.
+ * @param ltid  Local thread position in the threadgroup.
+ * @param lsize Threadgroup size.
  */
 kernel void lifeStep(
     texture2d<uint, access::read>  src   [[texture(0)]],
     texture2d<uint, access::write> dst   [[texture(1)]],
-    constant uint3&                wh1   [[buffer(0)]], // width, height, dummy
-    constant uint&                 wrap  [[buffer(1)]], // 0: clamp, 1: torus
+    constant uint3&                wh1   [[buffer(0)]],
     uint2                          gid   [[thread_position_in_grid]],
     uint2                          ltid  [[thread_position_in_threadgroup]],
-    uint2                          gsize [[threads_per_grid]],
     uint2                          lsize [[threads_per_threadgroup]]
 ) {
-    const uint W = wh1.x;
-    const uint H = wh1.y;
-    if (gid.x >= W || gid.y >= H) {
-        return;
-    }
+    const int W = int(wh1.x);
+    const int H = int(wh1.y);
 
-    // Neighbor reader (integer coordinates).
-    auto r = [&](int x, int y) -> uint {
-        int ix = x, iy = y;
-        if (wrap == 1) {
-            ix = (ix % int(W) + int(W)) % int(W);
-            iy = (iy % int(H) + int(H)) % int(H);
-        } else {
-            ix = clamp(ix, 0, int(W) - 1);
-            iy = clamp(iy, 0, int(H) - 1);
+    // 18x18 shared tile = 16x16 core + 1-pixel halo on each side.
+    constexpr int TILE = 18;
+    threadgroup uint tile[TILE][TILE];
+
+    const int2 tileOrigin = int2(gid) - int2(ltid) - 1;
+
+    for (int j = int(ltid.y); j < TILE; j += int(lsize.y)) {
+        for (int i = int(ltid.x); i < TILE; i += int(lsize.x)) {
+            int2 gp = tileOrigin + int2(i, j);
+            if (kWrap) {
+                gp.x = ((gp.x % W) + W) % W;
+                gp.y = ((gp.y % H) + H) % H;
+            } else {
+                gp = clamp(gp, int2(0), int2(W - 1, H - 1));
+            }
+            tile[j][i] = src.read(uint2(gp)).r & 1u;
         }
-        return src.read(uint2(ix, iy)).r & 1u;
-    };
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    const int x = int(gid.x);
-    const int y = int(gid.y);
+    if (int(gid.x) >= W || int(gid.y) >= H) return;
 
-    uint s =
-        r(x - 1, y - 1) + r(x, y - 1) + r(x + 1, y - 1) +
-        r(x - 1, y    ) +                 r(x + 1, y    ) +
-        r(x - 1, y + 1) + r(x, y + 1) + r(x + 1, y + 1);
+    const uint lx = ltid.x + 1;
+    const uint ly = ltid.y + 1;
 
-    uint c = src.read(uint2(gid)).r & 1u;
+    uint s = tile[ly - 1][lx - 1] + tile[ly - 1][lx] + tile[ly - 1][lx + 1]
+           + tile[ly    ][lx - 1] +                     tile[ly    ][lx + 1]
+           + tile[ly + 1][lx - 1] + tile[ly + 1][lx] + tile[ly + 1][lx + 1];
+
+    uint c = tile[ly][lx];
     uint n = (c == 1u) ? ((s == 2u || s == 3u) ? 1u : 0u)
                        : ((s == 3u) ? 1u : 0u);
     dst.write(n, gid);

--- a/Packages/Sources/MyToyboxScreens/Shaders/ProgressiveBlurShader.metal
+++ b/Packages/Sources/MyToyboxScreens/Shaders/ProgressiveBlurShader.metal
@@ -3,65 +3,43 @@
 using namespace metal;
 
 namespace ProgressiveBlur {
-    /// Maximum blur radius supported by the kernel
+    /// Maximum blur radius supported by the kernel.
     constant int MAX_RADIUS = 100;
 
-    /// Max kernel size: for a radius of 100, kernel size = 201
-    constant int MAX_KERNEL_SIZE = 2 * MAX_RADIUS + 1;
-
-    /// Standard Gaussian function used to build blur kernel.
-    float gaussian(float x, float sigma) {
-        return exp(-0.5 * x * x / (sigma * sigma)) / (sigma * sqrt(2.0 * M_PI_F));
-    }
-
-    /// Generates a 1D Gaussian kernel normalized to a total sum of 1.
-    void getKernel(int radius, float sigma, float _kernel[MAX_KERNEL_SIZE]) {
-        float sum = 0.0;
-        for (int i = -radius; i <= radius; i++) {
-            int index = i + MAX_RADIUS;
-            _kernel[index] = gaussian(float(i), sigma);
-            sum += _kernel[index];
-        }
-        // Normalize the kernel
-        for (int i = MAX_RADIUS - radius; i <= MAX_RADIUS + radius; i++) {
-            _kernel[i] /= sum;
-        }
-    }
-
-    /// Shader entry point: applies a separable 2D Gaussian blur
-    /// whose intensity increases toward the bottom of the view.
-    [[ stitchable ]] half4 main(
+    /// 1D separable progressive Gaussian blur.
+    /// Call twice (axis=0 for horizontal, axis=1 for vertical) to achieve
+    /// a full 2D Gaussian blur in O(r) + O(r) instead of O(r^2).
+    ///
+    /// @param position  Fragment position in layer coordinates.
+    /// @param layer     SwiftUI sampling layer.
+    /// @param box       (cx, cy, width, height); height is used for progress.
+    /// @param radius    Base blur radius (capped to MAX_RADIUS).
+    /// @param axis      0.0 = horizontal pass, 1.0 = vertical pass.
+    [[ stitchable ]] half4 progressiveBlur1D(
         float2 position,
         SwiftUI::Layer layer,
         float4 box,
-        float radius
+        float radius,
+        float axis
     ) {
-        // Compute vertical progress: 0.0 (top) → 1.0 (bottom)
         float ratio = clamp(position.y / box.w, 0.0, 1.0);
+        radius *= smoothstep(0.0, 1.0, ratio);
 
-        // Scale blur radius based on vertical position
-        radius = radius * smoothstep(0, 1, ratio);
+        if (radius <= 0.0) return layer.sample(position);
 
-        // Skip blurring for radius = 0
-        if (radius <= 0) {
-            return layer.sample(position);
+        int r = min(int(radius), MAX_RADIUS);
+        float sigma = max(radius / 3.0, 1e-3);
+        float invTwoSigmaSq = -0.5 / (sigma * sigma);
+
+        float2 step = (axis < 0.5) ? float2(1.0, 0.0) : float2(0.0, 1.0);
+
+        half4 sum = half4(0.0h);
+        float wsum = 0.0;
+        for (int i = -r; i <= r; ++i) {
+            float w = exp(float(i * i) * invTwoSigmaSq);
+            sum  += half4(layer.sample(position + float(i) * step)) * half(w);
+            wsum += w;
         }
-
-        // Apply separable Gaussian blur
-        half4 sum = half4(0);
-        const int offset = int(radius);
-        const float sigma = radius / 3.0;
-        float _kernel[MAX_KERNEL_SIZE];
-        getKernel(offset, sigma, _kernel);
-
-        for (int y = -offset; y <= offset; y++) {
-            for (int x = -offset; x <= offset; x++) {
-                float2 point = position + float2(x, y);
-                sum += layer.sample(point)
-                    * _kernel[y + MAX_RADIUS] * _kernel[x + MAX_RADIUS];
-            }
-        }
-
-        return sum;
+        return sum / half(wsum);
     }
 }

--- a/Packages/Sources/MyToyboxScreens/Shaders/StableFluidKernels.metal
+++ b/Packages/Sources/MyToyboxScreens/Shaders/StableFluidKernels.metal
@@ -699,7 +699,8 @@ struct ImageParams {
  *      opposite to the UV's Y direction.
  *
  *   3. **Aspect mapping:** The simulation grid is square, but the background
- *      image may not be. `scalingMode` selects:
+ *      image may not be. The `kUseAspectFill` function constant (fixed at PSO
+ *      creation time) selects:
  *      - **Fit (letterbox):** entire image inside the square; bars may be black.
  *        - aspect > 1: letterbox top/bottom.
  *        - aspect <= 1: letterbox left/right.
@@ -724,7 +725,7 @@ struct ImageParams {
  *      勾配の Y 方向と UV の Y 方向が逆なので Y 成分は符号を反転。
  *
  *   3. **アスペクトマッピング：** シミュレーションは正方形だが背景画像はそうとは限らない。
- *      `scalingMode` で次を選択：
+ *      `kUseAspectFill` function constant（PSO 構築時に解決）で次を選択：
  *      - **フィット（レターボックス）：** 画像全体を正方形内に収める。帯は黒。
  *        - aspect > 1: 上下レターボックス。
  *        - aspect <= 1: 左右レターボックス。

--- a/Packages/Sources/MyToyboxScreens/Shaders/StableFluidKernels.metal
+++ b/Packages/Sources/MyToyboxScreens/Shaders/StableFluidKernels.metal
@@ -60,6 +60,22 @@ static inline int2 clampCoord(int2 coord, int2 bounds) {
     return clamp(coord, int2(0), bounds - 1);
 }
 
+/// Load an 18x18 tile (16x16 core + 1-pixel halo) from a float4 texture into
+/// threadgroup memory with clamped boundary handling.
+static inline void loadTile4(
+    threadgroup float4 tile[18][18],
+    texture2d<float, access::read> src,
+    uint2 ltid, uint2 lsize, uint2 gid, int2 bounds
+) {
+    const int2 origin = int2(gid) - int2(ltid) - 1;
+    for (int j = int(ltid.y); j < 18; j += int(lsize.y)) {
+        for (int i = int(ltid.x); i < 18; i += int(lsize.x)) {
+            int2 gp = clampCoord(origin + int2(i, j), bounds);
+            tile[j][i] = src.read(uint2(gp));
+        }
+    }
+}
+
 // ============================================================================
 // Compute: Brush – generate force and ink from touch input
 // ============================================================================
@@ -214,11 +230,11 @@ kernel void fluidAddForces(
  * @param gid   Thread position. スレッド位置。
  */
 kernel void fluidAdvect(
-    texture2d<float, access::sample> src    [[texture(0)]],
-    texture2d<float, access::write>  dst    [[texture(1)]],
-    sampler                          samp   [[sampler(0)]],
-    constant SimParams&              p      [[buffer(0)]],
-    uint2                            gid    [[thread_position_in_grid]]
+    texture2d<half, access::sample> src    [[texture(0)]],
+    texture2d<float, access::write> dst    [[texture(1)]],
+    sampler                         samp   [[sampler(0)]],
+    constant SimParams&             p      [[buffer(0)]],
+    uint2                           gid    [[thread_position_in_grid]]
 ) {
     uint w = src.get_width();
     uint h = src.get_height();
@@ -228,11 +244,11 @@ kernel void fluidAdvect(
         return;
     }
 
-    float2 vel = src.read(gid).xy;
+    float2 vel = float2(src.read(gid).xy);
     float2 prevPos = float2(gid) - p.deltaTime * vel;
     float2 clamped = clamp(prevPos, float2(-0.5), float2(float(w), float(h)) - 0.5);
     float2 uv = (clamped + 0.5) / float2(float(w), float(h));
-    float4 sampled = src.sample(samp, uv);
+    float4 sampled = float4(src.sample(samp, uv));
     dst.write(sampled, gid);
 }
 
@@ -287,19 +303,26 @@ kernel void fluidAdvect(
  * @param gid  Thread position. スレッド位置。
  */
 kernel void fluidDiffusion(
-    texture2d<float, access::read>  src [[texture(0)]],
-    texture2d<float, access::write> dst [[texture(1)]],
-    constant SimParams&             p   [[buffer(0)]],
-    uint2                           gid [[thread_position_in_grid]]
+    texture2d<float, access::read>  src  [[texture(0)]],
+    texture2d<float, access::write> dst  [[texture(1)]],
+    constant SimParams&             p    [[buffer(0)]],
+    uint2                           gid  [[thread_position_in_grid]],
+    uint2                           ltid [[thread_position_in_threadgroup]],
+    uint2                           lsize [[threads_per_threadgroup]]
 ) {
-    int2 pos = int2(gid);
+    threadgroup float4 tile[18][18];
     int2 size = int2(src.get_width(), src.get_height());
-    float4 center = src.read(gid);
+    loadTile4(tile, src, ltid, lsize, gid, size);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    float4 left  = src.read(uint2(clampCoord(pos + int2(-1, 0), size)));
-    float4 right = src.read(uint2(clampCoord(pos + int2( 1, 0), size)));
-    float4 up    = src.read(uint2(clampCoord(pos + int2( 0,-1), size)));
-    float4 down  = src.read(uint2(clampCoord(pos + int2( 0, 1), size)));
+    if (int(gid.x) >= size.x || int(gid.y) >= size.y) return;
+
+    const uint lx = ltid.x + 1, ly = ltid.y + 1;
+    float4 center = tile[ly][lx];
+    float4 left   = tile[ly][lx - 1];
+    float4 right  = tile[ly][lx + 1];
+    float4 up     = tile[ly - 1][lx];
+    float4 down   = tile[ly + 1][lx];
 
     float alpha = 1.0 / max(p.viscosity * p.deltaTime, 1e-6);
     float blend = 1.0 / (4.0 + alpha);
@@ -341,17 +364,24 @@ kernel void fluidDiffusion(
  * @param gid  Thread position. スレッド位置。
  */
 kernel void fluidDivergence(
-    texture2d<float, access::read>  vel [[texture(0)]],
-    texture2d<float, access::write> div [[texture(1)]],
-    uint2                           gid [[thread_position_in_grid]]
+    texture2d<float, access::read>  vel   [[texture(0)]],
+    texture2d<float, access::write> div   [[texture(1)]],
+    uint2                           gid   [[thread_position_in_grid]],
+    uint2                           ltid  [[thread_position_in_threadgroup]],
+    uint2                           lsize [[threads_per_threadgroup]]
 ) {
-    int2 pos = int2(gid);
+    threadgroup float4 tile[18][18];
     int2 size = int2(vel.get_width(), vel.get_height());
+    loadTile4(tile, vel, ltid, lsize, gid, size);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    float leftVx  = vel.read(uint2(clampCoord(pos + int2(-1, 0), size))).x;
-    float rightVx = vel.read(uint2(clampCoord(pos + int2( 1, 0), size))).x;
-    float upVy    = vel.read(uint2(clampCoord(pos + int2( 0,-1), size))).y;
-    float downVy  = vel.read(uint2(clampCoord(pos + int2( 0, 1), size))).y;
+    if (int(gid.x) >= size.x || int(gid.y) >= size.y) return;
+
+    const uint lx = ltid.x + 1, ly = ltid.y + 1;
+    float leftVx  = tile[ly][lx - 1].x;
+    float rightVx = tile[ly][lx + 1].x;
+    float upVy    = tile[ly - 1][lx].y;
+    float downVy  = tile[ly + 1][lx].y;
 
     float d = 0.5 * (rightVx - leftVx + downVy - upVy);
     div.write(float4(d, 0.0, 0.0, 1.0), gid);
@@ -396,18 +426,25 @@ kernel void fluidDivergence(
  * @param gid  Thread position. スレッド位置。
  */
 kernel void fluidPressure(
-    texture2d<float, access::read>  x   [[texture(0)]],
-    texture2d<float, access::read>  b   [[texture(1)]],
-    texture2d<float, access::write> out [[texture(2)]],
-    uint2                           gid [[thread_position_in_grid]]
+    texture2d<float, access::read>  x     [[texture(0)]],
+    texture2d<float, access::read>  b     [[texture(1)]],
+    texture2d<float, access::write> out   [[texture(2)]],
+    uint2                           gid   [[thread_position_in_grid]],
+    uint2                           ltid  [[thread_position_in_threadgroup]],
+    uint2                           lsize [[threads_per_threadgroup]]
 ) {
-    int2 pos = int2(gid);
+    threadgroup float4 tile[18][18];
     int2 size = int2(x.get_width(), x.get_height());
+    loadTile4(tile, x, ltid, lsize, gid, size);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    float left  = x.read(uint2(clampCoord(pos + int2(-1, 0), size))).x;
-    float right = x.read(uint2(clampCoord(pos + int2( 1, 0), size))).x;
-    float up    = x.read(uint2(clampCoord(pos + int2( 0,-1), size))).x;
-    float down  = x.read(uint2(clampCoord(pos + int2( 0, 1), size))).x;
+    if (int(gid.x) >= size.x || int(gid.y) >= size.y) return;
+
+    const uint lx = ltid.x + 1, ly = ltid.y + 1;
+    float left  = tile[ly][lx - 1].x;
+    float right = tile[ly][lx + 1].x;
+    float up    = tile[ly - 1][lx].x;
+    float down  = tile[ly + 1][lx].x;
 
     float divergence = b.read(gid).x;
     float pressure = 0.25 * (left + right + up + down - divergence);
@@ -457,15 +494,22 @@ kernel void fluidProject(
     texture2d<float, access::read>  vel      [[texture(0)]],
     texture2d<float, access::read>  pressure [[texture(1)]],
     texture2d<float, access::write> out      [[texture(2)]],
-    uint2                           gid      [[thread_position_in_grid]]
+    uint2                           gid      [[thread_position_in_grid]],
+    uint2                           ltid     [[thread_position_in_threadgroup]],
+    uint2                           lsize    [[threads_per_threadgroup]]
 ) {
-    int2 pos = int2(gid);
+    threadgroup float4 pTile[18][18];
     int2 size = int2(vel.get_width(), vel.get_height());
+    loadTile4(pTile, pressure, ltid, lsize, gid, size);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    float leftP  = pressure.read(uint2(clampCoord(pos + int2(-1, 0), size))).x;
-    float rightP = pressure.read(uint2(clampCoord(pos + int2( 1, 0), size))).x;
-    float upP    = pressure.read(uint2(clampCoord(pos + int2( 0,-1), size))).x;
-    float downP  = pressure.read(uint2(clampCoord(pos + int2( 0, 1), size))).x;
+    if (int(gid.x) >= size.x || int(gid.y) >= size.y) return;
+
+    const uint lx = ltid.x + 1, ly = ltid.y + 1;
+    float leftP  = pTile[ly][lx - 1].x;
+    float rightP = pTile[ly][lx + 1].x;
+    float upP    = pTile[ly - 1][lx].x;
+    float downP  = pTile[ly + 1][lx].x;
 
     float2 grad = float2(0.5 * (rightP - leftP), 0.5 * (downP - upP));
     float2 v = vel.read(gid).xy - grad;
@@ -496,12 +540,12 @@ kernel void fluidProject(
  * @param gid   Thread position. スレッド位置。
  */
 kernel void fluidAdvectInk(
-    texture2d<float, access::read>   vel  [[texture(0)]],
-    texture2d<float, access::sample> src  [[texture(1)]],
-    texture2d<float, access::write>  dst  [[texture(2)]],
-    sampler                          samp [[sampler(0)]],
-    constant SimParams&              p    [[buffer(0)]],
-    uint2                            gid  [[thread_position_in_grid]]
+    texture2d<float, access::read>  vel  [[texture(0)]],
+    texture2d<half, access::sample> src  [[texture(1)]],
+    texture2d<float, access::write> dst  [[texture(2)]],
+    sampler                         samp [[sampler(0)]],
+    constant SimParams&             p    [[buffer(0)]],
+    uint2                           gid  [[thread_position_in_grid]]
 ) {
     uint w = src.get_width();
     uint h = src.get_height();
@@ -510,7 +554,7 @@ kernel void fluidAdvectInk(
     float2 prevPos = float2(gid) - p.deltaTime * v;
     float2 clamped = clamp(prevPos, float2(-0.5), float2(float(w), float(h)) - 0.5);
     float2 uv = (clamped + 0.5) / float2(float(w), float(h));
-    float4 sampled = src.sample(samp, uv);
+    float4 sampled = float4(src.sample(samp, uv));
     dst.write(sampled, gid);
 }
 
@@ -582,13 +626,13 @@ vertex VSOut fluidFullscreenVS(uint vid [[vertex_id]]) {
  * @param samp  Linear sampler. リニアサンプラー。
  * @return      RGBA fragment color. RGBA フラグメントカラー。
  */
-fragment float4 fluidInkFS(
-    VSOut                           in   [[stage_in]],
-    texture2d<float, access::sample> tex [[texture(0)]],
-    sampler                         samp [[sampler(0)]]
+fragment half4 fluidInkFS(
+    VSOut                          in   [[stage_in]],
+    texture2d<half, access::sample> tex [[texture(0)]],
+    sampler                        samp [[sampler(0)]]
 ) {
-    float density = tex.sample(samp, in.uv).x;
-    return float4(density, density * 0.8, density * 0.5, 1.0);
+    half d = tex.sample(samp, in.uv).x;
+    return half4(d, d * 0.8h, d * 0.5h, 1.0h);
 }
 
 // ============================================================================
@@ -611,35 +655,31 @@ fragment float4 fluidInkFS(
  * @param samp  Linear sampler. リニアサンプラー。
  * @return      RGBA fragment color. RGBA フラグメントカラー。
  */
-fragment float4 fluidVelocityFS(
-    VSOut                           in   [[stage_in]],
-    texture2d<float, access::sample> tex [[texture(0)]],
-    sampler                         samp [[sampler(0)]]
+fragment half4 fluidVelocityFS(
+    VSOut                          in   [[stage_in]],
+    texture2d<half, access::sample> tex [[texture(0)]],
+    sampler                        samp [[sampler(0)]]
 ) {
-    float2 vel = tex.sample(samp, in.uv).xy;
-    float mag = length(vel);
-    return float4((vel.x + 1.0) * 0.5, (vel.y + 1.0) * 0.5, mag * 0.4, 1.0);
+    half2 vel = tex.sample(samp, in.uv).xy;
+    half mag = length(vel);
+    return half4((vel.x + 1.0h) * 0.5h, (vel.y + 1.0h) * 0.5h, mag * 0.4h, 1.0h);
 }
 
 // ============================================================================
 // Fragment: Image distortion via ink density gradient (aspect fit / fill)
 // ============================================================================
 
-/// `ImageParams.scalingMode`: letterbox entire image inside the square viewport.
-/// `ImageParams.scalingMode`：画像全体を正方形ビューポート内にレターボックス表示。
-constant uint kImageScalingAspectFit = 0u;
-/// `ImageParams.scalingMode`: cover the square with center-cropped image.
-/// `ImageParams.scalingMode`：中央クロップで正方形を覆う。
-constant uint kImageScalingAspectFill = 1u;
+/// Scaling mode resolved at PSO creation time.
+/// true = aspect fill (center crop), false = aspect fit (letterbox).
+constant bool kUseAspectFill [[function_constant(0)]];
 
 /**
  * @brief  Parameters for the image-distortion fragment shader.
  *         画像歪みフラグメントシェーダ用パラメータ。
  */
 struct ImageParams {
-    float pixelStep;  ///< One pixel in UV space (1/gridWidth), for finite-difference gradient. UV 空間での 1 ピクセル幅（1/グリッド幅）、有限差分勾配用。
+    float pixelStep;   ///< One pixel in UV space (1/gridWidth). UV 空間での 1 ピクセル幅。
     float imageAspect; ///< Background image width / height. 背景画像の幅/高さ比。
-    uint scalingMode;  ///< `kImageScalingAspectFit` or `kImageScalingAspectFill`. フィットまたはフィル。
 };
 
 /**
@@ -704,29 +744,26 @@ struct ImageParams {
  * @param params  Image display parameters. 画像表示パラメータ。
  * @return        RGBA fragment color. RGBA フラグメントカラー。
  */
-fragment float4 fluidImageFS(
-    VSOut                            in      [[stage_in]],
-    texture2d<float, access::sample> inkTex  [[texture(0)]],
-    texture2d<float, access::sample> bgTex   [[texture(1)]],
-    sampler                          samp    [[sampler(0)]],
-    constant ImageParams&            params  [[buffer(0)]]
+fragment half4 fluidImageFS(
+    VSOut                           in      [[stage_in]],
+    texture2d<half, access::sample> inkTex  [[texture(0)]],
+    texture2d<float, access::sample> bgTex  [[texture(1)]],
+    sampler                         samp    [[sampler(0)]],
+    constant ImageParams&           params  [[buffer(0)]]
 ) {
     float ps = params.pixelStep;
-    float left  = inkTex.sample(samp, float2(in.uv.x - ps, in.uv.y)).x;
-    float right = inkTex.sample(samp, float2(in.uv.x + ps, in.uv.y)).x;
-    float up    = inkTex.sample(samp, float2(in.uv.x, in.uv.y + ps)).x;
-    float down  = inkTex.sample(samp, float2(in.uv.x, in.uv.y - ps)).x;
+    half left  = inkTex.sample(samp, float2(in.uv.x - ps, in.uv.y)).x;
+    half right = inkTex.sample(samp, float2(in.uv.x + ps, in.uv.y)).x;
+    half up    = inkTex.sample(samp, float2(in.uv.x, in.uv.y + ps)).x;
+    half down  = inkTex.sample(samp, float2(in.uv.x, in.uv.y - ps)).x;
 
-    float2 grad = float2(right - left, up - down);
+    float2 grad = float2(float(right - left), float(up - down));
     float strength = 0.8;
     float2 distorted = in.uv + grad * float2(strength, -strength);
 
     float aspect = params.imageAspect;
-    uint scaling = (params.scalingMode == kImageScalingAspectFill)
-        ? kImageScalingAspectFill
-        : kImageScalingAspectFit;
     float2 bgUV;
-    if (scaling == kImageScalingAspectFill) {
+    if (kUseAspectFill) {
         if (aspect > 1.0) {
             bgUV = float2(0.5 + (distorted.x - 0.5) / aspect, distorted.y);
         } else {
@@ -746,9 +783,9 @@ fragment float4 fluidImageFS(
     bgUV.y = 1.0 - bgUV.y;
 
     if (bgUV.x < 0.0 || bgUV.x > 1.0 || bgUV.y < 0.0 || bgUV.y > 1.0) {
-        return float4(0.0, 0.0, 0.0, 1.0);
+        return half4(0.0h, 0.0h, 0.0h, 1.0h);
     }
 
-    float4 color = bgTex.sample(samp, bgUV);
-    return float4(color.rgb, 1.0);
+    half4 color = half4(bgTex.sample(samp, bgUV));
+    return half4(color.rgb, 1.0h);
 }

--- a/Scripts/build_metallib.sh
+++ b/Scripts/build_metallib.sh
@@ -124,6 +124,7 @@ for metal_file in "${METAL_FILES[@]}"; do
     xcrun -sdk "$SDK" metal -c "$metal_file" \
         -std=metal3.2 \
         -target "$TRIPLE" \
+        -fmetal-math-mode=fast \
         -o "$BUILD_DIR/$filename.air" \
         $INCLUDE_ARGS \
         2>&1 || {


### PR DESCRIPTION
## Summary

- Add 18×18 threadgroup tiling to the Game of Life and four Stable Fluid Jacobi
  kernels (`fluidDiffusion`, `fluidDivergence`, `fluidPressure`, `fluidProject`),
  reducing global texture reads from 4–9 per thread to ~1 per thread.
- Replace runtime `if`-branches for boundary mode (Game of Life) and aspect-fill
  mode (Stable Fluid image display) with function constants baked into separate
  pre-compiled PSO variants, eliminating dead code paths at compile time.
- Rewrite the Progressive Blur shader as a 1D separable pass with an `axis`
  parameter; apply it twice (horizontal then vertical) in the SwiftUI modifier,
  reducing sampling cost from O(r²) to O(r)+O(r).
- Switch visualization fragment shaders and sampled-texture inputs to `half`
  precision; allocate all nine Stable Fluid simulation textures from a single
  `MTLHeap`; enable `-fmetal-math-mode=fast` in the Metal build script.

## Changes

- **`GameOfLifeKernels.metal`**: Replace 9 per-thread global reads and runtime
  `wrap` buffer with an 18×18 `threadgroup uint tile[18][18]` and `kWrap`
  function constant; fix threadgroup size to 16×16.
- **`MetalGameOfLifeView.swift`**: Build PSO via `MTLFunctionConstantValues`
  (`kWrap=true`) and `MTLComputePipelineDescriptor` with
  `threadGroupSizeIsMultipleOfThreadExecutionWidth = true`; remove runtime
  `setBytes(&wrap, …, index: 1)` and dynamic threadgroup size calculation.
- **`StableFluidKernels.metal`**:
  - Add `loadTile4` helper; convert `fluidDiffusion`, `fluidDivergence`,
    `fluidPressure`, `fluidProject` to 18×18 threadgroup tiling.
  - Change `fluidAdvect` and `fluidAdvectInk` sampled texture to
    `texture2d<half, access::sample>`; cast results to `float4` before write.
  - Switch `fluidInkFS`, `fluidVelocityFS`, `fluidImageFS` to return `half4`
    with `texture2d<half>` inputs.
  - Replace `ImageParams.scalingMode: uint` + `kImageScalingAspectFit/Fill`
    constants with `kUseAspectFill [[function_constant(0)]]`; remove the
    intermediate `uint scaling` variable.
- **`MetalStableFluidView.swift`**: Build all compute PSOs via
  `MTLComputePipelineDescriptor` with
  `threadGroupSizeIsMultipleOfThreadExecutionWidth = true`; split
  `imageRenderPSO` into `imageFitRenderPSO` / `imageFillRenderPSO` using
  `MTLFunctionConstantValues`; allocate nine textures from a single `MTLHeap`
  (`.private`, `.tracked`, device-level fallback); remove `scalingMode` from
  `ImageParamsBuffer`.
- **`StableFluidViewModel.swift`**: Remove `metalScalingMode: UInt32` computed
  property from `StableFluidImageContentMode`.
- **`ProgressiveBlurShader.metal`**: Replace 2D `main(float2, Layer, float4, float)`
  with 1D `progressiveBlur1D(float2, Layer, float4, float, float)` taking an
  `axis` parameter; compute Gaussian weights inline; normalize with `wsum`.
- **`ProgressiveBlurScreen.swift`**: Update `ShaderFunction` name to
  `ProgressiveBlur::progressiveBlur1D`; pass `.float(0)` / `.float(1)` as axis;
  chain two `.layerEffect` calls instead of one.
- **`Scripts/build_metallib.sh`**: Add `-fmetal-math-mode=fast` flag to the
  `xcrun metal -c` invocation.

## Motivation & Context

The Jacobi-based Stable Fluid kernels and the Game of Life step kernel each read
the same neighboring texels repeatedly across threads in the same threadgroup.
Threadgroup (tile) memory lets threads cooperatively load each texel once and
share it, directly reducing global memory bandwidth. Using function constants
instead of runtime branches moves mode selection to PSO compile time, so the GPU
compiler can fold away unused branches entirely. The separable 1D blur replaces
a nested-loop convolution that grows as O(r²) with two sequential O(r) passes
that produce the same result for a separable Gaussian kernel.

## Screenshots

Not applicable — performance and code-quality changes only.

## How to Test

1. Build and run on **iPhone 16 Pro Simulator (iOS 18.6)** — confirm no
   regression.
2. Navigate to **Game of Life**, **Stable Fluid**, and **Progressive Blur**;
   verify each renders and animates correctly.
3. In Stable Fluid, toggle display modes (Image / Ink / Velocity) and switch
   Aspect Fit ↔ Fill to confirm the `kUseAspectFill` PSO branch works.
4. In Stable Fluid image mode, drag to stir the fluid and verify the background
   image distortion is visually unchanged from the previous behavior.

## Notes for Reviewers

- All changes are behaviorally equivalent to the previous implementation; only
  GPU execution strategy and data precision differ.
- The `kWrap` function constant is fixed at `true` (torus boundary). A clamp
  variant PSO can be added later by introducing a `wrapBoundary` toggle in
  `GameOfLifeViewModel`.
- Stable Fluid textures now use `.private` storage (GPU-only). No CPU-side
  `replace(region:…)` or `getBytes` calls exist for these textures, so there
  is no correctness impact.

## Changelog

- `perf(metal)`: 18×18 threadgroup tiling for Game of Life (`lifeStep`) and Stable Fluid Jacobi kernels (`fluidDiffusion`, `fluidDivergence`, `fluidPressure`, `fluidProject`)
- `perf(metal)`: Function constants for boundary mode (`kWrap`) and aspect-fill mode (`kUseAspectFill`); eliminates runtime branches from PSO variants
- `perf(metal)`: Separable 1D progressive Gaussian blur (`progressiveBlur1D`) replaces 2D nested-loop convolution
- `perf(metal)`: Half-precision fragment shaders and sampled inputs; MTLHeap texture allocation; `-fmetal-math-mode=fast`