### PR TITLE
Ensure continuous thumbnail time during sidebar scroll

### DIFF
--- a/Packages/Sources/MyToyboxCore/ThumbnailScrollPauseAccumulator.swift
+++ b/Packages/Sources/MyToyboxCore/ThumbnailScrollPauseAccumulator.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Tracks wall-clock time spent while the sidebar list is scrolling so thumbnail `ThumbnailView` can pass a continuous logical time.
+struct ThumbnailScrollPauseAccumulator {
+    private(set) var accumulatedPauseDuration: TimeInterval = 0
+    private var pauseStart: Date?
+
+    /// - Parameters:
+    ///   - oldValue: Previous `isScrolling` from `onChange(of:initial:)`.
+    ///   - newValue: Current `isScrolling`.
+    ///   - now: Clock reading for the transition (typically `Date()`).
+    ///
+    /// When `initial` is `true`, the first invocation may pass equal values; if both are `true`, the list was already scrolling when the view appeared and scroll tracking starts at `now`.
+    mutating func onScrollingChanged(oldValue: Bool, newValue: Bool, now: Date) {
+        if oldValue != newValue {
+            if newValue {
+                pauseStart = now
+            } else {
+                if let start = pauseStart {
+                    accumulatedPauseDuration += now.timeIntervalSince(start)
+                }
+                pauseStart = nil
+            }
+        } else if newValue {
+            pauseStart = now
+        }
+    }
+
+    func logicalTime(wallElapsed: TimeInterval) -> TimeInterval {
+        wallElapsed - accumulatedPauseDuration
+    }
+}

--- a/Packages/Sources/MyToyboxCore/ThumbnailView.swift
+++ b/Packages/Sources/MyToyboxCore/ThumbnailView.swift
@@ -8,6 +8,7 @@ public extension EnvironmentValues {
 
 public struct ThumbnailView<Content: View>: View {
     @State private var now = Date.now
+    @State private var scrollPauseAccumulator = ThumbnailScrollPauseAccumulator()
     @Environment(\.isScrolling) private var isScrolling
     private var content: (_ isScrolling: Bool, _ time: TimeInterval) -> Content
 
@@ -17,11 +18,18 @@ public struct ThumbnailView<Content: View>: View {
 
     public var body: some View {
         TimelineView(.animation(paused: isScrolling)) { context in
-            content(isScrolling, context.date.timeIntervalSince(now))
+            let wallElapsed = context.date.timeIntervalSince(now)
+            let logicalTime = scrollPauseAccumulator.logicalTime(wallElapsed: wallElapsed)
+            content(isScrolling, logicalTime)
                 .transaction { transaction in
                     transaction.animation = !isScrolling ? transaction.animation : nil
                     transaction.disablesAnimations = isScrolling
                 }
+        }
+        .onChange(of: isScrolling, initial: true) { oldValue, newValue in
+            var accumulator = scrollPauseAccumulator
+            accumulator.onScrollingChanged(oldValue: oldValue, newValue: newValue, now: Date())
+            scrollPauseAccumulator = accumulator
         }
     }
 }

--- a/Packages/Tests/MyToyboxCoreTests/ThumbnailScrollPauseAccumulatorTests.swift
+++ b/Packages/Tests/MyToyboxCoreTests/ThumbnailScrollPauseAccumulatorTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import MyToyboxCore
+import Testing
+
+@Test func scrollPauseAccumulator_idleThenScrollThenIdle() {
+    let t0 = Date(timeIntervalSinceReferenceDate: 1_000)
+    let t1 = t0.addingTimeInterval(2)
+    let t2 = t1.addingTimeInterval(5)
+    let t3 = t2.addingTimeInterval(1)
+
+    var accumulator = ThumbnailScrollPauseAccumulator()
+
+    accumulator.onScrollingChanged(oldValue: false, newValue: false, now: t0)
+    #expect(accumulator.accumulatedPauseDuration == 0)
+    #expect(accumulator.logicalTime(wallElapsed: 10) == 10)
+
+    accumulator.onScrollingChanged(oldValue: false, newValue: true, now: t1)
+    #expect(accumulator.accumulatedPauseDuration == 0)
+
+    accumulator.onScrollingChanged(oldValue: true, newValue: false, now: t2)
+    #expect(accumulator.accumulatedPauseDuration == 5)
+
+    let wallElapsedAfterScroll = 100.0
+    #expect(accumulator.logicalTime(wallElapsed: wallElapsedAfterScroll) == 95)
+
+    accumulator.onScrollingChanged(oldValue: false, newValue: true, now: t2)
+    accumulator.onScrollingChanged(oldValue: true, newValue: false, now: t3)
+    #expect(accumulator.accumulatedPauseDuration == 6)
+}
+
+@Test func scrollPauseAccumulator_initialAlreadyScrolling() {
+    let t0 = Date(timeIntervalSinceReferenceDate: 2_000)
+    let t1 = t0.addingTimeInterval(3)
+
+    var accumulator = ThumbnailScrollPauseAccumulator()
+
+    accumulator.onScrollingChanged(oldValue: true, newValue: true, now: t0)
+    #expect(accumulator.accumulatedPauseDuration == 0)
+
+    accumulator.onScrollingChanged(oldValue: true, newValue: false, now: t1)
+    #expect(accumulator.accumulatedPauseDuration == 3)
+}
+
+@Test func scrollPauseAccumulator_logicalTimeStaysContinuousAcrossResume() {
+    let mount = Date(timeIntervalSinceReferenceDate: 5_000)
+    let scrollStart = mount.addingTimeInterval(1)
+    let scrollEnd = scrollStart.addingTimeInterval(4)
+
+    var accumulator = ThumbnailScrollPauseAccumulator()
+
+    let wallBeforeScroll = scrollStart.timeIntervalSince(mount)
+    accumulator.onScrollingChanged(oldValue: false, newValue: true, now: scrollStart)
+    #expect(accumulator.logicalTime(wallElapsed: wallBeforeScroll) == wallBeforeScroll)
+
+    accumulator.onScrollingChanged(oldValue: true, newValue: false, now: scrollEnd)
+    let wallAfterResume = scrollEnd.timeIntervalSince(mount)
+    let logicalAfterResume = accumulator.logicalTime(wallElapsed: wallAfterResume)
+    #expect(abs(logicalAfterResume - wallBeforeScroll) < 0.001)
+}


### PR DESCRIPTION
## Summary

- Fix discontinuous thumbnail `time` after the sidebar list stops scrolling: wall-clock
  elapsed no longer jumps forward by the whole scroll duration when
  `TimelineView(.animation(paused:))` resumes.
- Introduce `ThumbnailScrollPauseAccumulator` to subtract accumulated wall time spent
  while `EnvironmentValues.isScrolling` is `true`, so logical animation phase stays
  continuous for all `ScreenMetadata` thumbnails using `ThumbnailView`.
- Add Swift Testing coverage for scroll transitions (including initial “already
  scrolling” via `onChange(..., initial: true)`).

## Changes

- **`ThumbnailScrollPauseAccumulator.swift`** (new): Track `pauseStart` / accumulated
  pause duration; `onScrollingChanged(oldValue:newValue:now:)` and
  `logicalTime(wallElapsed:)`.
- **`ThumbnailView.swift`**: Compute `logicalTime` from `context.date` and accumulator;
  attach `onChange(of: isScrolling, initial: true)` to update the accumulator with
  `Date()`.
- **`ThumbnailScrollPauseAccumulatorTests.swift`** (new): Unit tests for idle → scroll
  → idle, initial already scrolling, and continuity across resume.

## Motivation & Context

`TimelineView` pauses its schedule while the list scrolls, so `context.date` freezes;
on release, the next tick snaps to real time and `timeIntervalSince(now)` jumped by
the full scroll interval. That made thumbnail animations look like they skipped ahead.
Subtracting the wall time accumulated during scroll sessions restores a stable logical
clock for `sin(time)`, `onChange(of: time)`, and similar consumers without changing
`RootScreen` or per-screen thumbnail code.

## Screenshots

Not applicable — behavior fix for sidebar list thumbnails; no new UI chrome.

## How to Test

1. Build and run on an iOS Simulator (e.g. iPhone) with the sidebar list visible.
2. Scroll the screen list for several seconds, then release; confirm thumbnails resume
   without a large phase jump compared to before (animations should continue smoothly
   from where they visually paused).
3. Short flings and repeated scroll/stop cycles — thumbnails should stay stable.
4. Spot-check screens that depend on `time` (e.g. **Color Hex Animation**,
   **Progress Ring**) for abnormal bursts of updates after scrolling.
5. **Package tests:** `swift build --target MyToyboxCoreTests && swift test --skip-build --filter MyToyboxCoreTests` (full `swift test` may build unrelated targets).

## Related Issues

- (none)

## Notes for Reviewers

- Single commit on top of `develop`; scope is **MyToyboxCore** only (`RootScreen` unchanged).
- `swift test` without `--skip-build` may compile the whole package; use
  `--skip-build` after building `MyToyboxCoreTests` if other targets fail locally.
- Optional follow-up (out of scope): `SqureflowScreen+Thumbnail` builds `Date` from
  `time` — verify semantics separately if needed.

## Changelog

- `fix(ui)`: continuous logical time for sidebar thumbnails while scrolling the screen list