### PR TITLE
Refactor iOS app structure and improve styling consistency

### DIFF
--- a/App/MyToybox.xcodeproj/project.pbxproj
+++ b/App/MyToybox.xcodeproj/project.pbxproj
@@ -308,9 +308,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.takehito.koshimizu.MyToybox;
 				PRODUCT_NAME = Toybox;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				XROS_DEPLOYMENT_TARGET = 2.2;
 			};
 			name = Debug;
@@ -348,9 +349,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.takehito.koshimizu.MyToybox;
 				PRODUCT_NAME = Toybox;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				XROS_DEPLOYMENT_TARGET = 2.2;
 			};
 			name = Release;

--- a/MyToybox.xcworkspace/xcshareddata/xcschemes/MyToybox.xcscheme
+++ b/MyToybox.xcworkspace/xcshareddata/xcschemes/MyToybox.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3A682A8E2D8D471000B110AC"
-               BuildableName = "MyToybox.app"
+               BuildableName = "Toybox.app"
                BlueprintName = "MyToybox"
                ReferencedContainer = "container:App/MyToybox.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3A682A8E2D8D471000B110AC"
-            BuildableName = "MyToybox.app"
+            BuildableName = "Toybox.app"
             BlueprintName = "MyToybox"
             ReferencedContainer = "container:App/MyToybox.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3A682A8E2D8D471000B110AC"
-            BuildableName = "MyToybox.app"
+            BuildableName = "Toybox.app"
             BlueprintName = "MyToybox"
             ReferencedContainer = "container:App/MyToybox.xcodeproj">
          </BuildableReference>

--- a/Packages/Sources/MyToyboxScreens/Screens/ArchimedesSpiral/ArchimedesSpiralScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ArchimedesSpiral/ArchimedesSpiralScreen.swift
@@ -23,7 +23,7 @@ struct ArchimedesSpiralScreen: View {
             // Reset the animation by setting a new start time.
             start = .now
         }
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/ColoredMap/ColoredMapScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ColoredMap/ColoredMapScreen.swift
@@ -24,7 +24,7 @@ struct ColoredMapScreen: View {
                 // Overlay a color-tinted transparent rectangle on top of the map.
                 Rectangle()
                     .foregroundStyle(Color(color))
-                    .ignoresSafeArea()
+                    .backgroundExtensionEffect()
                     .blendMode(.screen)
                     .allowsHitTesting(false)
             }

--- a/Packages/Sources/MyToyboxScreens/Screens/ComplexNumber/ComplexNumberScreen+Thumbnail.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ComplexNumber/ComplexNumberScreen+Thumbnail.swift
@@ -13,5 +13,5 @@ extension ComplexNumberScreen {
 
 #Preview {
     RippleScreen.thumbnail
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/ComplexNumber/ComplexNumberScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ComplexNumber/ComplexNumberScreen.swift
@@ -9,7 +9,7 @@ struct ComplexNumberScreen: View {
 
     var body: some View {
         ComplexShaderView(shaderMode: shaderMode, functionIndex: selection.rawValue)
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
             .overlay(content: picker)
             .toolbar(content: menu)
     }

--- a/Packages/Sources/MyToyboxScreens/Screens/CosmicWeb/CosmicWebDemoScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/CosmicWeb/CosmicWebDemoScreen.swift
@@ -30,7 +30,7 @@ struct CosmicWebScreen: View {
             // The current time, used to animate the shader pattern.
             let time = context.date.timeIntervalSinceReferenceDate
             Rectangle()
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
                 .layerEffect(.cosmicWeb(time: time), maxSampleOffset: .zero)
         }
     }

--- a/Packages/Sources/MyToyboxScreens/Screens/JuliaSet/JuliaSetScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/JuliaSet/JuliaSetScreen.swift
@@ -45,7 +45,7 @@ private struct JuliaSetGestureView: View {
                     .gesture(dragGesture(size: size))
                     .gesture(magnification)
             }
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
 
             VStack {
                 Spacer()

--- a/Packages/Sources/MyToyboxScreens/Screens/Meshgradient/Meshgradient2Screen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Meshgradient/Meshgradient2Screen.swift
@@ -46,7 +46,7 @@ struct Meshgradient2Screen: View {
             .fontWeight(.semibold)
             .background {
                 Color.black
-                    .ignoresSafeArea()
+                    .backgroundExtensionEffect()
             }
             .onChange(of: colors.count) { _, _ in
                 offsets = [CGSize](repeating: .zero, count: colors.count * colors.count)
@@ -175,7 +175,7 @@ struct MeshView: View {
                     offsets = [CGSize](repeating: .zero, count: width * height)
                 }
             }
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
         }
     }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/MonotoneMap/MonotoneMapScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/MonotoneMap/MonotoneMapScreen.swift
@@ -21,7 +21,7 @@ struct MonotoneMapScreen: View {
             .overlay {
                 // This overlay desaturates the underlying map using blend mode.
                 Rectangle()
-                    .ignoresSafeArea()
+                    .backgroundExtensionEffect()
                     .blendMode(.saturation)
                     .allowsHitTesting(false)
             }

--- a/Packages/Sources/MyToyboxScreens/Screens/PhysicsTag/PhysicsTagScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/PhysicsTag/PhysicsTagScreen.swift
@@ -20,7 +20,7 @@ struct PhysicsTagScreen: View {
 
     var body: some View {
         SpriteView(scene: scene)
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
             .overlay(alignment: .topTrailing) {
                 VStack(alignment: .leading, spacing: 10) {
                     Toggle(isOn: $usesDeviceMotion) {

--- a/Packages/Sources/MyToyboxScreens/Screens/PrettyHip/PrettyHipScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/PrettyHip/PrettyHipScreen.swift
@@ -13,7 +13,7 @@ struct PrettyHipScreen: View {
             Rectangle()
                 .foregroundStyle(.white)
                 .colorEffect(.prettyHip(elapsed: elapsed))
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
         }
     }
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/PrimeSpiral/PrimeSpiralScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/PrimeSpiral/PrimeSpiralScreen.swift
@@ -21,7 +21,7 @@ struct PrimeSpiralScreen: View {
 
             PrimeSpiralContent(scale: scale, color: color)
         }
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
         .background(.black)
         .onTapGesture {
             // Restart the animation from zero on tap.

--- a/Packages/Sources/MyToyboxScreens/Screens/RandomMetaball2D/RandomMetaballDemoScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/RandomMetaball2D/RandomMetaballDemoScreen.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct RandomMetaballDemoScreen: View {
     var body: some View {
         RandomMetaball2DView(particleCount: 50)
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/RectangleAnimation/RectangleAnimationScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/RectangleAnimation/RectangleAnimationScreen.swift
@@ -39,7 +39,7 @@ struct RectangleAnimationScreen: View {
             }
             .id(geometry.size)
             .background(Color(red: 0.137, green: 0.137, blue: 0.137))
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
         }
     }
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/RingSlider/RingSliderScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/RingSlider/RingSliderScreen.swift
@@ -13,7 +13,7 @@ struct RingSliderScreen: View {
             // Background color with hue rotation based on slider value
             Color(hue: 1, saturation: 0.3, brightness: 1)
                 .hueRotation(.degrees(360 * ratio))
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
 
             // The interactive ring slider
             RingSlider(ratio: $ratio)

--- a/Packages/Sources/MyToyboxScreens/Screens/Ripple/RippleScreen+Thumbnail.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Ripple/RippleScreen+Thumbnail.swift
@@ -48,5 +48,5 @@ private struct IsEnabledModifier<M: ViewModifier>: ViewModifier {
 
 #Preview {
     RippleScreen.thumbnail
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootCell.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootCell.swift
@@ -1,6 +1,35 @@
 import MyToyboxCore
 import SwiftUI
 
+// MARK: - RootCellStyle
+
+/// Visual variants for a root list row.
+///
+/// The style controls whether the cell shows a leading preview thumbnail
+/// or renders as text-only.
+enum RootCellStyle {
+    /// Text-focused row style without a leading preview.
+    case textOnly
+    /// Row style that shows a leading preview thumbnail.
+    case previewLeading
+
+    /// Returns whether the style renders a leading preview.
+    var showsLeadingPreview: Bool {
+        switch self {
+        case .textOnly:
+            false
+        case .previewLeading:
+            true
+        }
+    }
+}
+
+/// Environment value used by `RootCell` to resolve its visual style.
+extension EnvironmentValues {
+    /// The current style applied to root list cells.
+    @Entry var rootCellStyle: RootCellStyle = .textOnly
+}
+
 // MARK: - RootCell
 
 /// A single row view used by the root screen list.
@@ -11,7 +40,8 @@ struct RootCell: View {
     let isScrolling: Bool
     /// Baseline row height used for square thumbnail sizing.
     @Environment(\.defaultMinListRowHeight) private var defaultMinListRowHeight
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    /// The style context that controls whether a leading preview is shown.
+    @Environment(\.rootCellStyle) private var style
 
     var body: some View {
         HStack(alignment: .top) {
@@ -27,8 +57,7 @@ struct RootCell: View {
 private extension RootCell {
     @ViewBuilder
     var thumbnailView: some View {
-#if os(iOS)
-        if horizontalSizeClass == .compact {
+        if style.showsLeadingPreview {
             ZStack {
                 Color.clear
                 screen.thumbnail
@@ -38,7 +67,6 @@ private extension RootCell {
             .frame(width: defaultMinListRowHeight, height: defaultMinListRowHeight)
             .clipShape(.rect(cornerRadius: 8))
         }
-#endif
     }
 
     var labelView: some View {

--- a/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootCompactView.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootCompactView.swift
@@ -11,6 +11,8 @@ struct RootCompactView: View {
     var body: some View {
         NavigationStack {
             RootSidebarView(screens: screens)
+                // Compact layouts keep the richer row style with leading previews.
+                .environment(\.rootCellStyle, .previewLeading)
         }
     }
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/Root/Screen/RootScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Root/Screen/RootScreen.swift
@@ -20,7 +20,6 @@ public struct RootScreen: View {
 
     public var body: some View {
         contentView
-            .tint(.white)
             // Force dark mode appearance 😎
             .preferredColorScheme(.dark)
             .environment(viewModel.tags)

--- a/Packages/Sources/MyToyboxScreens/Screens/ShaderTile/TileShaderScreen+Thumbnail.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ShaderTile/TileShaderScreen+Thumbnail.swift
@@ -9,7 +9,7 @@ extension TileShaderScreen {
         Rectangle()
             .colorEffect(.tile(scale: scale))
             .foregroundStyle(.blue.mix(with: .white, by: 0.3))
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/ShaderTile/TileShaderScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/ShaderTile/TileShaderScreen.swift
@@ -22,7 +22,7 @@ struct TileShaderScreen: View {
             Rectangle()
                 .colorEffect(.tile(scale: scale))
                 .foregroundStyle(.blue.mix(with: .white, by: 0.3))
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
         }
     }
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/Shine/ShineScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Shine/ShineScreen.swift
@@ -20,7 +20,7 @@ struct ShineScreen: View {
                 .colorEffect(.shine(time: seconds))
         }
         // Extend the effect to fill the entire screen
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/SmoothMin/SmoothMinScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/SmoothMin/SmoothMinScreen.swift
@@ -14,7 +14,7 @@ struct SmoothMinScreen: View {
                 Rectangle()
                     .colorEffect(.smoothMin2d(k: value, time: seconds))
             }
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
 
             VStack {
                 Spacer()

--- a/Packages/Sources/MyToyboxScreens/Screens/SpiralShader/SpiralShaderScreen+Thumbnail.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/SpiralShader/SpiralShaderScreen+Thumbnail.swift
@@ -7,7 +7,7 @@ extension SpiralShaderScreen {
         Rectangle()
             .colorEffect(.spiral(scale: scale))
             .foregroundStyle(.red.mix(with: .white, by: 0.3))
-            .ignoresSafeArea()
+            .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/SpiralShader/SpiralShaderScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/SpiralShader/SpiralShaderScreen.swift
@@ -14,7 +14,7 @@ struct SpiralShaderScreen: View {
             Rectangle()
                 .colorEffect(.spiral(scale: scale))
                 .foregroundStyle(.red.mix(with: .white, by: 0.3))
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
         }
     }
 }

--- a/Packages/Sources/MyToyboxScreens/Screens/Squreflow/SqureflowScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Squreflow/SqureflowScreen.swift
@@ -16,7 +16,7 @@ struct SqureflowScreen: View {
                 }
             }
         }
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/TileAnimation/TileAnimationScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/TileAnimation/TileAnimationScreen.swift
@@ -9,11 +9,11 @@ struct TileAnimationScreen: View {
     var body: some View {
         if let viewModel {
             ContentView(viewModel: viewModel, lineWidth: 16)
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
                 .id([viewModel.row, viewModel.column])
         } else {
             Color.clear
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
                 .onGeometryChange(for: CGSize.self, of: \.size) { _, size in
                     setup(with: size)
                 }
@@ -59,7 +59,7 @@ private extension TileAnimationScreen {
                 }
                 .scaledToFit()
                 .foregroundStyle(.blue)
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
                 .animation(.spring(duration: 0.8), value: viewModel.rotations)
                 .onChange(of: interval, initial: true) { _, interval in
                     if interval > 1 {

--- a/Packages/Sources/MyToyboxScreens/Screens/TileAnimation3D/TileAnimation3DScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/TileAnimation3D/TileAnimation3DScreen.swift
@@ -23,7 +23,7 @@ struct TileAnimation3DScreen: View {
             viewModel = ViewModel(row: row, column: column)
             lineWidth = min(size.height, size.width) / Double(min(row, column)) / 5
         }
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/VoronoiDiagram/VoronoiDiagramDemoScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/VoronoiDiagram/VoronoiDiagramDemoScreen.swift
@@ -60,7 +60,7 @@ private struct AnimatableShaderView: View {
                         .shadow(radius: 4)
                         .shadow(radius: 5)
                 }
-                .ignoresSafeArea()
+                .backgroundExtensionEffect()
         }
     }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/WaveParticle/WaveParticleScreen.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/WaveParticle/WaveParticleScreen.swift
@@ -12,7 +12,7 @@ struct WaveParticleScreen: View {
             Rectangle()
                 .colorEffect(.waveParticle(time: time))
         }
-        .ignoresSafeArea()
+        .backgroundExtensionEffect()
     }
 }
 

--- a/Packages/Sources/MyToyboxScreens/Utils/View+BackgroundExtension.swift
+++ b/Packages/Sources/MyToyboxScreens/Utils/View+BackgroundExtension.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    @_disfavoredOverload
+    func backgroundExtensionEffect() -> some View {
+        if #available(iOS 26.0, *) {
+            self.SwiftUI::backgroundExtensionEffect()
+        } else {
+            // Fallback on earlier versions
+            self.ignoresSafeArea()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR streamlines platform/build configuration and UI styling consistency for the `develop` branch by removing unsupported target settings, fixing scheme naming, and centralizing background compatibility handling in screen views.

## Changes

- Removed visionOS-related target configuration and adjusted project/scheme settings to match the current app target strategy.
- Refactored root list cell preview styling to rely on environment-driven behavior instead of ad-hoc styling in each usage site.
- Removed unintended global white tint impact in the root screen flow.
- Added a shared background compatibility helper (`View+BackgroundExtension`) and migrated affected screens/thumbnails to use the unified API.

## Motivation & Context

- Project target/scheme settings had drifted from the active platform scope, creating maintenance noise.
- Styling behavior in root/list preview flows was harder to reason about due to scattered per-screen handling.
- Centralizing background fallback logic reduces repeated compatibility code and keeps rendering behavior consistent across many screens.
