### PR TITLE
Add zoom navigation transition to root sidebar

### DIFF
--- a/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootCell.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootCell.swift
@@ -38,6 +38,8 @@ struct RootCell: View {
     let screen: Screen
     /// Indicates whether the list is actively scrolling.
     let isScrolling: Bool
+    /// The namespace used for coordinating a navigation transition.
+    var namespace: Namespace.ID? = nil
     /// Baseline row height used for square thumbnail sizing.
     @Environment(\.defaultMinListRowHeight) private var defaultMinListRowHeight
     /// The style context that controls whether a leading preview is shown.
@@ -57,7 +59,7 @@ struct RootCell: View {
 private extension RootCell {
     @ViewBuilder
     var thumbnailView: some View {
-        if style.showsLeadingPreview {
+        if style.showsLeadingPreview, let namespace {
             ZStack {
                 Color.clear
                 screen.thumbnail
@@ -66,6 +68,7 @@ private extension RootCell {
             .background(.black.gradient)
             .frame(width: defaultMinListRowHeight, height: defaultMinListRowHeight)
             .clipShape(.rect(cornerRadius: 8))
+            .matchedTransitionSource(id: screen, in: namespace)
         }
     }
 

--- a/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootSidebarView.swift
+++ b/Packages/Sources/MyToyboxScreens/Screens/Root/Components/RootSidebarView.swift
@@ -12,6 +12,9 @@ struct RootSidebarView: View {
     /// Tracks scroll activity for thumbnail rendering optimization.
     @State private var isScrolling = false
 
+    /// The namespace used for coordinating a navigation transition.
+    @Namespace private var namespace
+
     init(screens: [Screen], selection: Binding<Screen?>? = nil) {
         self.screens = screens
         self.selection = selection
@@ -46,8 +49,9 @@ private extension RootSidebarView {
             List(screens, id: \.self) { screen in
                 NavigationLink {
                     RootDetailView(selection: screen)
+                        .navigationTransition(.zoom(sourceID: screen, in: namespace))
                 } label: {
-                    RootCell(screen: screen, isScrolling: isScrolling)
+                    RootCell(screen: screen, isScrolling: isScrolling, namespace: namespace)
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR improves root navigation reliability by removing timeline-driven thumbnail updates that crashed during pushes and pops, and adds a zoom-style transition from each sidebar row’s thumbnail to its detail screen. `ThumbnailView` keeps the same `(isScrolling, time)` callback shape for `ScreenMetadata` thumbnails; thumbnails are effectively static at a fixed phase. Sidebar navigation wires `matchedTransitionSource` on the cell preview and `.navigationTransition(.zoom(...))` on the pushed detail.

## Changes

- **`RootSidebarView` / `RootCell`**: Add `@Namespace`, optional `namespace` on `RootCell`, `.matchedTransitionSource(id:in:)` on the leading thumbnail when present, and `.navigationTransition(.zoom(sourceID:in:))` on `RootDetailView`.

