### PR TITLE
Feat(app-clip): add my-toybox.web.app as associated domain

### DIFF
--- a/App/MyToybox.xcodeproj/project.pbxproj
+++ b/App/MyToybox.xcodeproj/project.pbxproj
@@ -382,7 +382,6 @@
 		3A682AB52D8D471100B110AC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_CLIP_ASSOCIATED_DOMAIN = "koshimizu-takehito.github.io";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = MyToybox/Resources/MyToybox.entitlements;
@@ -426,7 +425,6 @@
 		3A682AB62D8D471100B110AC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_CLIP_ASSOCIATED_DOMAIN = "koshimizu-takehito.github.io";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = MyToybox/Resources/MyToybox.entitlements;
@@ -470,7 +468,6 @@
 		7B40C1FA2F0A100100A0A001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_CLIP_ASSOCIATED_DOMAIN = "koshimizu-takehito.github.io";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = MyToyboxClip/Resources/MyToyboxClip.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -505,7 +502,6 @@
 		7B40C1FB2F0A100100A0A001 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_CLIP_ASSOCIATED_DOMAIN = "koshimizu-takehito.github.io";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = MyToyboxClip/Resources/MyToyboxClip.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";

--- a/App/MyToybox/Resources/MyToybox.entitlements
+++ b/App/MyToybox/Resources/MyToybox.entitlements
@@ -6,7 +6,8 @@
 	<true/>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:$(APP_CLIP_ASSOCIATED_DOMAIN)</string>
+		<string>applinks:koshimizu-takehito.github.io</string>
+		<string>applinks:my-toybox.web.app</string>
 	</array>
 </dict>
 </plist>

--- a/App/MyToyboxClip/Resources/MyToyboxClip.entitlements
+++ b/App/MyToyboxClip/Resources/MyToyboxClip.entitlements
@@ -10,8 +10,10 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:$(APP_CLIP_ASSOCIATED_DOMAIN)</string>
-		<string>appclips:$(APP_CLIP_ASSOCIATED_DOMAIN)</string>
+		<string>applinks:koshimizu-takehito.github.io</string>
+		<string>applinks:my-toybox.web.app</string>
+		<string>appclips:koshimizu-takehito.github.io</string>
+		<string>appclips:my-toybox.web.app</string>
 	</array>
 </dict>
 </plist>

--- a/Docs/AppClip-Runbook.ja.md
+++ b/Docs/AppClip-Runbook.ja.md
@@ -1,7 +1,9 @@
 # App Clip Runbook（日本語）
 
 ## URLルーティング
-- GitHub Pages プロジェクトサイト: `/my-toybox-clip/<screen-id>`（ホスト直下から **2 要素**: `my-toybox-clip`、`<screen-id>`）
+- パスルート: `/my-toybox-clip/<screen-id>`（ホスト直下から **2 要素**: `my-toybox-clip`、`<screen-id>`）
+  - GitHub Pages: `https://koshimizu-takehito.github.io/my-toybox-clip/<screen-id>`
+  - Firebase: `https://my-toybox.web.app/my-toybox-clip/<screen-id>`
 - クエリルート: `?screen=<screen-id>`（パスより優先）
 - 厳密パス規則: 上記の **2 要素パターン**のみ受理。それ以外の区切り数・先頭セグメントは拒否
 - **廃止**（意図的に未対応）: `/clip/<screen-id>`、`/.well-known/clip/<screen-id>`
@@ -86,8 +88,10 @@ sequenceDiagram
 | 13 | `https://example.com/?screen=RingSliderScreen` | `RingSliderScreen` | false | fallback | case-sensitive（routeID不一致） |
 | 14 | `https://example.com/foo/my-toybox-clip/ringSliderScreen?screen=badgeDemoScreen` | `badgeDemoScreen` | true | destination | query優先のため path reject を無視 |
 | 15 | `https://koshimizu-takehito.github.io/my-toybox-clip/ringSliderScreen` | `ringSliderScreen` | true | destination | 本番 GitHub Pages URL |
-| 16 | `https://example.com/other-repo/ringSliderScreen` | nil | false | fallback | 先頭セグメントが `my-toybox-clip` でない |
-| 17 | `https://example.com/clip/ringSliderScreen` | nil | false | fallback | 廃止パス（未対応） |
+| 16 | `https://my-toybox.web.app/my-toybox-clip/ringSliderScreen` | `ringSliderScreen` | true | destination | 本番 Firebase URL |
+| 17 | `https://my-toybox.web.app/?screen=ringSliderScreen` | `ringSliderScreen` | true | destination | Firebase クエリルート |
+| 18 | `https://example.com/other-repo/ringSliderScreen` | nil | false | fallback | 先頭セグメントが `my-toybox-clip` でない |
+| 19 | `https://example.com/clip/ringSliderScreen` | nil | false | fallback | 廃止パス（未対応） |
 
 ### 注記
 - Resolverの出力は `RouteResolver` の返り値に基づく。
@@ -95,10 +99,11 @@ sequenceDiagram
 - decode once の期待値は Foundation のURLパース挙動に依存するため、将来差分が出た場合は表も更新する。
 
 ## 関連ドメイン
-- 次でアプリ/クリップ双方の entitlements を設定する:
-  - `applinks:<your-domain>`
-  - `appclips:<your-domain>`（クリップターゲット）
-- 設定ごとに `APP_CLIP_ASSOCIATED_DOMAIN` のビルド設定を更新する。
+- ドメインはエンタイトルメントに直接記述（ビルド変数不使用）:
+  - `koshimizu-takehito.github.io` — GitHub Pages
+  - `my-toybox.web.app` — Firebase Hosting
+- App Clip エンタイトルメント: 両ドメインに `applinks:` + `appclips:`
+- 親アプリ エンタイトルメント: 両ドメインに `applinks:`
 
 ## 検証チェックリスト
 - App / App Clip ターゲットが `Screen` を直接参照せずにコンパイルできること

--- a/Docs/AppClip-Runbook.md
+++ b/Docs/AppClip-Runbook.md
@@ -1,7 +1,9 @@
 # App Clip Runbook
 
 ## URL Routing
-- GitHub Pages project site: `/my-toybox-clip/<screen-id>` (exactly two path segments from the host root: `my-toybox-clip`, `<screen-id>`).
+- Path route: `/my-toybox-clip/<screen-id>` (exactly two path segments: `my-toybox-clip`, `<screen-id>`).
+  - GitHub Pages: `https://koshimizu-takehito.github.io/my-toybox-clip/<screen-id>`
+  - Firebase: `https://my-toybox.web.app/my-toybox-clip/<screen-id>`
 - Query route: `?screen=<screen-id>` (higher priority than path)
 - Strict path rule: accept only the **two-segment** pattern above; reject any other component counts or leading segments.
 - Deprecated (intentionally unsupported): `/clip/<screen-id>`, `/.well-known/clip/<screen-id>`.
@@ -86,8 +88,10 @@ This runbook describes the same behavior enforced by the following code paths:
 | 13 | `https://example.com/?screen=RingSliderScreen` | `RingSliderScreen` | false | fallback | case-sensitive (routeID mismatch) |
 | 14 | `https://example.com/foo/my-toybox-clip/ringSliderScreen?screen=badgeDemoScreen` | `badgeDemoScreen` | true | destination | query priority overrides path reject |
 | 15 | `https://koshimizu-takehito.github.io/my-toybox-clip/ringSliderScreen` | `ringSliderScreen` | true | destination | production GitHub Pages URL |
-| 16 | `https://example.com/other-repo/ringSliderScreen` | nil | false | fallback | first segment is not `my-toybox-clip` |
-| 17 | `https://example.com/clip/ringSliderScreen` | nil | false | fallback | deprecated path (no longer supported) |
+| 16 | `https://my-toybox.web.app/my-toybox-clip/ringSliderScreen` | `ringSliderScreen` | true | destination | production Firebase URL |
+| 17 | `https://my-toybox.web.app/?screen=ringSliderScreen` | `ringSliderScreen` | true | destination | Firebase query route |
+| 18 | `https://example.com/other-repo/ringSliderScreen` | nil | false | fallback | first segment is not `my-toybox-clip` |
+| 19 | `https://example.com/clip/ringSliderScreen` | nil | false | fallback | deprecated path (no longer supported) |
 
 ### Notes
 - Resolver output is based on the return value of `RouteResolver`.
@@ -95,10 +99,11 @@ This runbook describes the same behavior enforced by the following code paths:
 - The expected "decode once" behavior depends on Foundation URL parsing semantics, so update the table if it changes in the future.
 
 ## Associated Domains
-- Configure both app and clip entitlements with:
-  - `applinks:<your-domain>`
-  - `appclips:<your-domain>` (clip target)
-- Update `APP_CLIP_ASSOCIATED_DOMAIN` build setting per configuration.
+- Domains are hardcoded directly in entitlements (no build variables):
+  - `koshimizu-takehito.github.io` — GitHub Pages
+  - `my-toybox.web.app` — Firebase Hosting
+- App Clip entitlements: `applinks:` + `appclips:` for both domains.
+- Parent app entitlements: `applinks:` for both domains.
 
 ## Validation Checklist
 - App / App Clip targets compile without any direct `Screen` references.

--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -738,7 +738,7 @@ let package = Package(
         // MARK: - Tests
         .testTarget(
             name: "MyToyboxCoreTests",
-            dependencies: ["MyToyboxCore", "MyToyboxClipScreens"],
+            dependencies: ["MyToyboxCore", "MyToyboxScreens"],
             path: "Tests/MyToyboxCoreTests"
         ),
     ]

--- a/Packages/Tests/MyToyboxCoreTests/ScreenResolverTests.swift
+++ b/Packages/Tests/MyToyboxCoreTests/ScreenResolverTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MyToyboxClipScreens
+import MyToyboxScreens
 @testable import MyToyboxCore
 import Testing
 
@@ -24,6 +24,18 @@ import Testing
 
     @Test func pathSegmentWithoutTrailingSlash() {
         let url = URL(string: "https://example.com/my-toybox-clip/badgeDemoScreen")!
+        let id: Screen? = ScreenResolver.screen(from: url)
+        #expect(id == .badgeDemoScreen)
+    }
+
+    @Test func firebaseDomainPath() {
+        let url = URL(string: "https://my-toybox.web.app/my-toybox-clip/badgeDemoScreen/")!
+        let id: Screen? = ScreenResolver.screen(from: url)
+        #expect(id == .badgeDemoScreen)
+    }
+
+    @Test func firebaseDomainQuery() {
+        let url = URL(string: "https://my-toybox.web.app/?screen=badgeDemoScreen")!
         let id: Screen? = ScreenResolver.screen(from: url)
         #expect(id == .badgeDemoScreen)
     }


### PR DESCRIPTION
## Summary

- Add `my-toybox.web.app` as an Associated Domain so App Clip / deep links work on both domains

## Changes

| File | Change |
|---|---|
| `MyToyboxClip.entitlements` | Hardcode both domains for `applinks:` and `appclips:` |
| `MyToybox.entitlements` | Hardcode both domains for `applinks:` |
| `project.pbxproj` | Remove `APP_CLIP_ASSOCIATED_DOMAIN` build setting (4 occurrences) |
| `ScreenResolverTests.swift` | Add 2 Firebase domain test cases; fix import to `MyToyboxScreens` |
| `Package.swift` | Change test dependency from `MyToyboxClipScreens` to `MyToyboxScreens` |
| `AppClip-Runbook.md/.ja.md` | Add Firebase URL examples and updated domain configuration |
