### PR TITLE
Align documentation with module structure and enhance README badges

### DIFF
--- a/.claude/commands/new-screen.md
+++ b/.claude/commands/new-screen.md
@@ -17,11 +17,11 @@ You are the **screen-creator** agent. Your mission is to create a complete, buil
 2. **Validate Naming**
    - Ensure screen name is UpperCamelCase
    - Convert to lowerCamelCase for the enum case ID (e.g., "ParticleExplosion" → "particleExplosionScreen")
-   - Verify the ID doesn't already exist in `Packages/Sources/MyToyboxCatalog/Screen.swift`
+   - Verify the ID doesn't already exist in `Packages/Sources/AppScreens/AppScreen.swift`
 
-3. **Update Screen.swift**
-   - Read `Packages/Sources/MyToyboxCatalog/Screen.swift`
-   - Add new case to the `enum Screen` in lowerCamelCase with "Screen" suffix:
+3. **Update AppScreen.swift**
+   - Read `Packages/Sources/AppScreens/AppScreen.swift`
+   - Add new case to the `enum AppScreen` in lowerCamelCase with "Screen" suffix:
      ```swift
      case particleExplosionScreen
      ```
@@ -122,11 +122,11 @@ You are the **screen-creator** agent. Your mission is to create a complete, buil
 
 - If screen ID already exists, suggest an alternative name
 - If build fails, diagnose Metal compilation errors or Swift syntax issues
-- If validation fails, check Screen.swift formatting
+- If validation fails, check AppScreen.swift formatting
 
 ## Success Criteria
 
-- `Screen.swift` contains the new case
+- `AppScreen.swift` contains the new case
 - SwiftUI view file compiles without errors
 - Thumbnail file exists and provides a non-empty implementation
 - Metal shader compiles (if created)

--- a/.claude/commands/review-architecture.md
+++ b/.claude/commands/review-architecture.md
@@ -61,7 +61,7 @@ struct RootScreen: View {
 - Bundle resources via SPM resource bundles
 - Metal shaders: Accessed via `ShaderLibrary.module`
 - JSON loading: Use `Bundle.module.url(forResource:withExtension:)`
-- Assets: `Media.xcassets` in `MyToyboxUI`
+- Assets: `Media.xcassets` in `MyToyboxMedia`
 
 ### 5. YAGNI (You Aren't Gonna Need It)
 **DO**:

--- a/.claude/commands/sync-docs.md
+++ b/.claude/commands/sync-docs.md
@@ -16,7 +16,7 @@ You are the **documentation-writer** agent. Your mission is to keep documentatio
 ### Secondary Documentation
 4. **Makefile** (inline help text)
 5. **Package.swift** (package documentation)
-6. **Screen.swift** (screen enum cases)
+6. **AppScreen.swift** (screen enum cases)
 7. **Code comments** (inline documentation)
 
 ## Sync Tasks
@@ -258,7 +258,7 @@ make command-name ARG=example
 
 ### New Screen Entry
 
-**In `Screen.swift`** (add a new case to `enum Screen`):
+**In `AppScreen.swift`** (add a new case to `enum AppScreen`):
 ```swift
 case newEffectScreen
 ```

--- a/.claude/commands/validate-screens.md
+++ b/.claude/commands/validate-screens.md
@@ -1,16 +1,16 @@
 # Screen Validator
 
-Validate `Screen.swift` case names and synchronization with screen implementations.
+Validate `AppScreen.swift` case names and synchronization with screen implementations.
 
 ## Task
 
-You are the **screen-validator** agent. Your mission is to ensure `Screen.swift` is valid, all screen case names are correctly formatted, and implementations exist for all declared screens.
+You are the **screen-validator** agent. Your mission is to ensure `AppScreen.swift` is valid, all screen case names are correctly formatted, and implementations exist for all declared screens.
 
 ## Validation Steps
 
 ### 1. Screen Case Name Validation
-- Read `Packages/Sources/MyToyboxCatalog/Screen.swift`
-- For each `case` in `enum Screen`:
+- Read `Packages/Sources/AppScreens/AppScreen.swift`
+- For each `case` in `enum AppScreen`:
   - **Format Check**: Case name must be a valid Swift identifier
     - Regex: `^[a-zA-Z_][a-zA-Z0-9_]*$`
     - Must be lowerCamelCase
@@ -23,7 +23,7 @@ You are the **screen-validator** agent. Your mission is to ensure `Screen.swift`
 - Warn if tags are empty, but do not treat as an error
 
 ### 3. Implementation Validation
-For each case in `Screen`, verify the corresponding implementation exists:
+For each case in `AppScreen`, verify the corresponding implementation exists:
 
 **Case to File Mapping**:
 - Case: `gameOfLifeScreen` → File: `Packages/Sources/Screens/GameOfLife/GameOfLifeScreen.swift`
@@ -44,16 +44,16 @@ For each screen, verify a `+Thumbnail.swift` file exists:
 - The default implementation in `ScreenMetadata` returns an empty view — all screens should override it
 
 ### 5. Orphan Detection
-Find screen implementations without `Screen` enum entries:
+Find screen implementations without `AppScreen` enum entries:
 - Scan `Packages/Sources/Screens/` for all subdirectories
-- For each directory, check if a corresponding case exists in `Screen.swift`
+- For each directory, check if a corresponding case exists in `AppScreen.swift`
 - Report any orphaned implementations
 
 ### 6. Run Official Validation Script
 ```bash
 bash Scripts/check_screen_sync.sh
 ```
-This script validates that all case names in `Screen.swift` are valid Swift identifiers and unique.
+This script validates that all case names in `AppScreen.swift` are valid Swift identifiers and unique.
 
 ## Common Issues and Fixes
 
@@ -70,12 +70,12 @@ This script validates that all case names in `Screen.swift` are valid Swift iden
 **Fix**: Rename one to a unique identifier
 
 ### Issue: Implementation File Missing
-**Example**: `Screen.swift` has `case newEffectScreen` but no corresponding Swift file
+**Example**: `AppScreen.swift` has `case newEffectScreen` but no corresponding Swift file
 **Fix**: Either remove the case or create the implementation file
 
 ### Issue: Orphaned Implementation
-**Example**: `Packages/Sources/Screens/UnusedEffect/` exists but no case in `Screen.swift`
-**Fix**: Add case to `Screen.swift` or remove the directory
+**Example**: `Packages/Sources/Screens/UnusedEffect/` exists but no case in `AppScreen.swift`
+**Fix**: Add case to `AppScreen.swift` or remove the directory
 
 ## Validation Report Format
 
@@ -83,7 +83,7 @@ This script validates that all case names in `Screen.swift` are valid Swift iden
 # Screen Validation Report
 
 ## Summary
-- Total screens in Screen.swift: X
+- Total screens in AppScreen.swift: X
 - Valid entries: Y
 - Issues found: Z
 
@@ -100,7 +100,7 @@ This script validates that all case names in `Screen.swift` are valid Swift iden
 ✗ missingScreen    → Missing/MissingScreen.swift NOT FOUND
 
 ## Orphaned Implementations
-✗ OrphanedEffect/OrphanedEffectScreen.swift - No Screen enum case
+✗ OrphanedEffect/OrphanedEffectScreen.swift - No AppScreen enum case
 
 ## Recommendations
 1. Fix invalid case name: invalid-screen → invalidScreen
@@ -110,19 +110,19 @@ This script validates that all case names in `Screen.swift` are valid Swift iden
 
 ## Steps to Execute
 
-1. **Read Screen.swift** — Count cases
+1. **Read AppScreen.swift** — Count cases
 2. **Validate Each Case** — Check name format, find implementation and thumbnail
-3. **Scan for Orphans** — List all screen directories, cross-reference with `Screen.swift`
+3. **Scan for Orphans** — List all screen directories, cross-reference with `AppScreen.swift`
 4. **Run Official Script** — `bash Scripts/check_screen_sync.sh`
 5. **Generate Report** — Summarize findings with actionable recommendations
 
 ## Success Criteria
 
-- All cases in `Screen.swift` are valid Swift identifiers
+- All cases in `AppScreen.swift` are valid Swift identifiers
 - All case names are unique
 - All implementations exist
 - All screens have a non-empty thumbnail override
 - No orphaned implementations (or documented as intentional)
 - `check_screen_sync.sh` passes without errors
 
-Begin validation by reading `Screen.swift` and running through the checklist.
+Begin validation by reading `AppScreen.swift` and running through the checklist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,17 +24,17 @@ make clean
 ```bash
 # Build
 xcodebuild -workspace MyToybox.xcworkspace -scheme MyToybox \
-  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' \
   CODE_SIGNING_ALLOWED=NO clean build
 
 # Run all tests
 xcodebuild -workspace MyToybox.xcworkspace -scheme MyToybox \
-  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' \
   CODE_SIGNING_ALLOWED=NO test
 
 # Run specific test
 xcodebuild test -workspace MyToybox.xcworkspace -scheme MyToybox \
-  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' \
   -only-testing MyToyboxCoreTests/MyToyboxCoreTests/testName \
   CODE_SIGNING_ALLOWED=NO
 ```
@@ -45,19 +45,23 @@ This is an iOS/macOS visual effects showcase app (Swift 6.3, SwiftUI, Metal) wit
 
 **Module Structure:**
 - `App/MyToybox/` - Xcode app entry point (`App.swift` → `RootScreen`)
-- `Packages/Sources/MyToyboxCore/` - Shared models and utilities (`ScreenMetadata`, `Tag`, `ThumbnailView`) + URL routing
-- `Packages/Sources/MyToyboxUI/` - Root navigation UI shell: `RootScreen`, adaptive layouts, `DeepLinkSheet`
-- `Packages/Sources/Screens/TagPicker/` - Tag filter UI (SPM module `TagPicker`): `TagPicker`, flow layout
-- `Packages/Sources/MyToyboxCatalog/` - Screen catalog: `Screen.swift` enum defining all available screens
-- `Packages/Sources/MyToyboxClipCatalog/` - App Clip screen catalog (subset of screens)
+- `Packages/Sources/MyToyboxCore/` - Shared models and utilities (`ScreenMetadata`, `Tag`, `ThumbnailView`, `DeepLinkSheet`) + URL routing
+- `Packages/Sources/MyToyboxMedia/` - Shared media assets for shader-based screens
+- `Packages/Sources/PlatformSupport/` - Platform abstraction utilities
+- `Packages/Sources/AppScreens/` - Screen catalog: `AppScreen.swift` enum defining all available screens
+- `Packages/Sources/ClipScreens/` - App Clip screen catalog (subset of screens)
+- `Packages/Sources/MockScreens/` - Mock screen catalog for previews/testing
+- `Packages/Sources/Screens/RootScreen/` - Root navigation UI shell: adaptive layouts (sidebar/split/compact)
+- `Packages/Sources/Screens/DetailScreen/` - Detail view for individual screens
+- `Packages/Sources/Screens/TagPicker/` - Tag filter UI: `TagPicker`, flow layout
 
 **Code Generation via SPM Plugins:**
 - `BuildMetalShaders` plugin: `.metal` files → `default.metallib`
-- `@Screens` macro (from [ScreenMacros](https://github.com/Koshimizu-Takehito/ScreenMacros)): converts `Screen` cases to View types
+- `@Screens` macro (from [ScreenMacros](https://github.com/Koshimizu-Takehito/ScreenMacros)): converts `AppScreen` cases to View types
 - `@Metadatas` / `@Metadata` macros (from `MetadatasMacros/`): generate `ScreenMetadata` conformance (`title`, `description`, `tags`, `thumbnail`) for each screen
 
 **Screen Registration:**
-- Single source of truth: `Packages/Sources/MyToyboxCatalog/Screen.swift`
+- Single source of truth: `Packages/Sources/AppScreens/AppScreen.swift`
 - Each screen case name must be a valid Swift identifier in lowerCamelCase (e.g., `gameOfLifeScreen`)
 - Screen implementations live in `Packages/Sources/Screens/{ScreenName}/`
 

--- a/Docs/AppClip-Runbook.ja.md
+++ b/Docs/AppClip-Runbook.ja.md
@@ -15,7 +15,7 @@
 - `RouteID`: アプリ間で受け渡す外部向けルート識別子
 - `RouteCatalog`: クリップアイテムとルート可否のSSOT（Single Source of Truth）
 - `RouteRootScreen`: App Clip と、フルアプリ側のフォールバック表示の両方で利用する公開エントリビュー
-- `Screen` は `MyToyboxCatalog` 内部（internal）のままであり、`App/*` から参照してはならない
+- `AppScreen` は `AppScreens` 内部（internal）のままであり、`App/*` から参照してはならない
 
 ## 呼び出し元
 - App Clip Code

--- a/Docs/AppClip-Runbook.md
+++ b/Docs/AppClip-Runbook.md
@@ -15,7 +15,7 @@
 - `RouteID`: external route identifier passed between app layers.
 - `RouteCatalog`: single source of truth for clip items and route availability.
 - `RouteRootScreen`: public clip entry view for both App Clip and full app fallback presentation.
-- `Screen` remains internal to `MyToyboxCatalog` and must never be referenced in `App/*`.
+- `AppScreen` remains internal to `AppScreens` and must never be referenced in `App/*`.
 
 ## Invocation Sources
 - App Clip Code

--- a/LOCALIZATION_WORKFLOW.md
+++ b/LOCALIZATION_WORKFLOW.md
@@ -18,7 +18,6 @@ Verify under each target's Build Settings → Localization.
 ```
 Packages/Sources/
 ├── MyToyboxCore/Resources/Localizable.xcstrings       # app.*
-├── MyToyboxUI/Resources/Localizable.xcstrings         # app.title
 ├── Screens/TagPicker/Resources/Localizable.xcstrings  # tag.*
 └── Screens/<Name>/Resources/Localizable.xcstrings    # screen.<id>.title / .description
 ```
@@ -42,9 +41,9 @@ in Xcode regenerates the symbol and surfaces compile errors at the call site.
 
 ## Key naming convention
 
-- `app.*` — app-wide UI strings (`MyToyboxCore` / `MyToyboxUI`)
+- `app.*` — app-wide UI strings (`MyToyboxCore`)
 - `tag.*` — tag labels and tag picker UI (`TagPicker`)
 - `screen.<id>.title` / `screen.<id>.description` — per-screen metadata
 
-`<id>` is the lowerCamelCase form of the `Screen` enum case name (without the
+`<id>` is the lowerCamelCase form of the `AppScreen` enum case name (without the
 `Screen` suffix). For example, `case badgeDemoScreen` → `screen.badgeDemo.*`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,11 +4,14 @@
 ![Swift](https://img.shields.io/badge/swift-6.3-orange.svg)
 ![MIT](https://img.shields.io/badge/license-MIT-black)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Koshimizu-Takehito/my-toybox)
+[![App Clip](https://img.shields.io/badge/App%20Clip-Instant-000000?logo=apple&logoColor=white)](https://appclip.apple.com/id?p=com.takehito.koshimizu.MyToybox.MyToyboxClip)
 
 **my-toybox** は、SwiftUI と Metal を活用したさまざまなアニメーションや描画のサンプルを集めた iOS/macOS アプリプロジェクトです。  
 複数の画面（Screen）が用意されており、各画面では個性的な UI エフェクトやアニメーションを試すことができます。
 
 <a href="https://apps.apple.com/app/id6743644224" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&h=b17e195bc020808628890cbe7fcde25f" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
+
+> 📎 [App Clip でインストール不要で試す（iOS のみ）](https://appclip.apple.com/id?p=com.takehito.koshimizu.MyToybox.MyToyboxClip)
 
 ## 概要
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,8 @@
 **my-toybox** は、SwiftUI と Metal を活用したさまざまなアニメーションや描画のサンプルを集めた iOS/macOS アプリプロジェクトです。  
 複数の画面（Screen）が用意されており、各画面では個性的な UI エフェクトやアニメーションを試すことができます。
 
+<a href="https://apps.apple.com/app/id6743644224" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&h=b17e195bc020808628890cbe7fcde25f" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
+
 ## 概要
 
 - **言語 / フレームワーク**: Swift 6.3, SwiftUI, Metal  

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,8 +22,8 @@
 
 ### 🔹 豊富なサンプル画面 (Screen)
 `Packages/Sources/Screens/` 以下の各フォルダに画面モジュールがあり、それぞれが独自のアニメーションや描画ロジックを持ちます。  
-`Packages/Sources/MyToyboxCatalog/Screen.swift` で画面の識別子を一元管理しています。  
-`enum Screen` の case 名は**Swift の識別子として有効な lowerCamelCase（例: `gameOfLifeScreen`）** で記述する必要があります。
+`Packages/Sources/AppScreens/AppScreen.swift` で画面の識別子を一元管理しています。  
+`enum AppScreen` の case 名は**Swift の識別子として有効な lowerCamelCase（例: `gameOfLifeScreen`）** で記述する必要があります。
 
 ### 🔹 SPM ビルドツールプラグイン
 このプロジェクトでは SPM プラグインを使用してビルド時に自動でリソースをコンパイルします：
@@ -32,7 +32,7 @@
 |-----------|------|------|
 | `BuildMetalShaders` | `.metal` ファイル | `default.metallib`（コンパイル済みシェーダー） |
 
-`@Screens` マクロ ([ScreenMacros](https://github.com/Koshimizu-Takehito/ScreenMacros)) により、各 `Screen` case が対応する `View` 型に変換されます。
+`@Screens` マクロ ([ScreenMacros](https://github.com/Koshimizu-Takehito/ScreenMacros)) により、各 `AppScreen` case が対応する `View` 型に変換されます。
 
 ### 🔹 Metal シェーダーによる表現
 `MosaicShader.metal` や `WaveParticleShader.metal` など、Metal シェーダーファイルを用いたビジュアルエフェクトを多数実装しています。  
@@ -68,12 +68,16 @@ my-toybox/
   │   │   ├─ MyToyboxCore/         # コアプロトコルと共有ユーティリティ
   │   │   │   ├─ ScreenMetadata.swift  # 画面メタデータ＆サムネイルのプロトコル定義
   │   │   │   ├─ Tag.swift             # 画面カテゴリ用 Tag enum
-  │   │   │   └─ ThumbnailView.swift   # サムネイル表示ラッパー
-  │   │   ├─ MyToyboxUI/           # ルートナビゲーション（RootScreen、レイアウト）
-  │   │   ├─ MyToyboxCatalog/      # Screen.swift と全画面モジュールの配線
-  │   │   ├─ MyToyboxClipCatalog/  # App Clip 向け画面カタログ（サブセット）
+  │   │   │   ├─ ThumbnailView.swift   # サムネイル表示ラッパー
+  │   │   │   └─ DeepLinkSheet.swift   # URL ベースのディープリンク処理
+  │   │   ├─ AppScreens/           # AppScreen.swift と全画面モジュールの配線
+  │   │   ├─ ClipScreens/          # App Clip 向け画面カタログ（サブセット）
+  │   │   ├─ MockScreens/          # プレビュー・テスト用モック画面カタログ
+  │   │   ├─ PlatformSupport/      # プラットフォーム抽象化（PlatformViewRepresentable）
   │   │   ├─ MyToyboxMedia/        # シェーダー画面向け共有メディア
   │   │   └─ Screens/              # 画面ごとの SPM モジュール（SwiftUI ＋任意で Metal）
+  │   │       ├─ RootScreen/       # ルートナビゲーション（サイドバー、分割、コンパクトレイアウト）
+  │   │       ├─ DetailScreen/     # 個別画面の詳細ビュー
   │   │       ├─ TagPicker/        # タグフィルター UI（SPM モジュール TagPicker）
   │   │       └─ …                 # その他の画面モジュール（Badge、GameOfLife など）
   │   └─ Tests/
@@ -88,9 +92,9 @@ my-toybox/
 
 **主要ファイル:**
 - `App.swift`: アプリのエントリーポイント。`RootScreen` が初期画面として指定されています。
-- `Packages/Sources/MyToyboxUI/RootScreen.swift`: アプリ起動時に表示される「画面一覧＋詳細表示」のメインビュー。
-- `Packages/Sources/MyToyboxUI/RootScreenModel.swift`: カタログ一覧の取得・タグによるフィルタリングなどを担当。
-- `Packages/Sources/MyToyboxCatalog/Screen.swift`: すべての画面を定義する enum とメタデータを含むファイル。
+- `Packages/Sources/Screens/RootScreen/RootScreen.swift`: アプリ起動時に表示される「画面一覧＋詳細表示」のメインビュー。
+- `Packages/Sources/Screens/RootScreen/RootScreenModel.swift`: カタログ一覧の取得・タグによるフィルタリングなどを担当。
+- `Packages/Sources/AppScreens/AppScreen.swift`: すべての画面を定義する enum とメタデータを含むファイル。
 
 ## インストール & ビルド手順
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 **my-toybox** is an experimental iOS/macOS app project that showcases a wide variety of SwiftUI and Metal-based visual effects and animations.  
 It acts as a sandbox or "toybox" of interactive screens where you can explore different UI techniques and graphics rendering approaches.
 
+<a href="https://apps.apple.com/app/id6743644224" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&h=b17e195bc020808628890cbe7fcde25f" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
+
 ## Overview
 
 - **Languages & Frameworks**: Swift 6.3, SwiftUI, Metal  

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ It acts as a sandbox or "toybox" of interactive screens where you can explore di
 - **Recommended**: Xcode 26.4.1 or later  
 
 The app displays a list of sample screens (referred to as "screens") on launch. Each screen demonstrates a unique animation or visual effect.  
-Screens are loaded dynamically from the `Screen` enum and rendered using SwiftUI and, in some cases, custom Metal shaders.
+Screens are loaded dynamically from the `AppScreen` enum and rendered using SwiftUI and, in some cases, custom Metal shaders.
 
 ## Key Features
 
 ### 🔹 Dozens of Sample Screens
 Each screen lives under `Packages/Sources/Screens/<ScreenName>/` and showcases a specific animation, layout, or rendering technique.  
-The screen list is defined in `Packages/Sources/MyToyboxCatalog/Screen.swift`.  
-Each case name in `enum Screen` **must be a valid Swift identifier in lowerCamelCase (e.g. `gameOfLifeScreen`)**.
+The screen list is defined in `Packages/Sources/AppScreens/AppScreen.swift`.  
+Each case name in `enum AppScreen` **must be a valid Swift identifier in lowerCamelCase (e.g. `gameOfLifeScreen`)**.
 
 ### 🔹 SPM Build Tool Plugins
 This project uses SPM plugins to automatically compile resources during build:
@@ -34,7 +34,7 @@ This project uses SPM plugins to automatically compile resources during build:
 |--------|-------|--------|
 | `BuildMetalShaders` | `.metal` files | `default.metallib` (compiled shaders) |
 
-The `@Screens` macro ([ScreenMacros](https://github.com/Koshimizu-Takehito/ScreenMacros)) converts each `Screen` case into a corresponding `View` type.
+The `@Screens` macro ([ScreenMacros](https://github.com/Koshimizu-Takehito/ScreenMacros)) converts each `AppScreen` case into a corresponding `View` type.
 
 ### 🔹 Metal Shaders
 Some effects (like mosaic or particle waves) are implemented with `.metal` shader files using SwiftUI's shader support.
@@ -69,12 +69,16 @@ my-toybox/
   │   │   ├─ MyToyboxCore/         # Core protocols and shared utilities
   │   │   │   ├─ ScreenMetadata.swift  # Protocol defining screen metadata & thumbnail
   │   │   │   ├─ Tag.swift             # Tag enum for screen categorization
-  │   │   │   └─ ThumbnailView.swift   # Reusable thumbnail view wrapper
-  │   │   ├─ MyToyboxUI/           # Root navigation shell (RootScreen, layouts)
-  │   │   ├─ MyToyboxCatalog/      # Screen.swift enum; wires all screen modules
-  │   │   ├─ MyToyboxClipCatalog/  # App Clip screen catalog (subset)
+  │   │   │   ├─ ThumbnailView.swift   # Reusable thumbnail view wrapper
+  │   │   │   └─ DeepLinkSheet.swift   # URL-based deep link handling
+  │   │   ├─ AppScreens/           # AppScreen.swift enum; wires all screen modules
+  │   │   ├─ ClipScreens/          # App Clip screen catalog (subset)
+  │   │   ├─ MockScreens/          # Mock screen catalog for previews/testing
+  │   │   ├─ PlatformSupport/      # Platform abstraction (PlatformViewRepresentable)
   │   │   ├─ MyToyboxMedia/        # Shared media for shader-based screens
   │   │   └─ Screens/              # One SPM module per screen (SwiftUI + optional Metal)
+  │   │       ├─ RootScreen/       # Root navigation shell (sidebar, split, compact layouts)
+  │   │       ├─ DetailScreen/     # Detail view for individual screens
   │   │       ├─ TagPicker/        # Tag filter UI (SPM module TagPicker)
   │   │       └─ …                 # Other screen modules (Badge, GameOfLife, …)
   │   └─ Tests/
@@ -89,9 +93,9 @@ my-toybox/
 
 **Key Files:**
 - `App.swift`: The app's `@main` entry point, launching the `RootScreen`.
-- `Packages/Sources/MyToyboxUI/RootScreen.swift`: The master-detail view listing all available screens.
-- `Packages/Sources/MyToyboxUI/RootScreenModel.swift`: Handles sidebar selection and tag filtering state for the catalog.
-- `Packages/Sources/MyToyboxCatalog/Screen.swift`: Enum defining all available screens with their metadata.
+- `Packages/Sources/Screens/RootScreen/RootScreen.swift`: The master-detail view listing all available screens.
+- `Packages/Sources/Screens/RootScreen/RootScreenModel.swift`: Handles sidebar selection and tag filtering state for the catalog.
+- `Packages/Sources/AppScreens/AppScreen.swift`: Enum defining all available screens with their metadata.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Swift](https://img.shields.io/badge/swift-6.3-orange.svg)
 ![MIT](https://img.shields.io/badge/license-MIT-black)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Koshimizu-Takehito/my-toybox)
+[![App Clip](https://img.shields.io/badge/App%20Clip-Instant-000000?logo=apple&logoColor=white)](https://appclip.apple.com/id?p=com.takehito.koshimizu.MyToybox.MyToyboxClip)
 
 ![Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-05-11 at 15 32 02](https://github.com/user-attachments/assets/8b5ecc14-1224-4de7-9160-622aee2fb723)
 
@@ -11,6 +12,8 @@
 It acts as a sandbox or "toybox" of interactive screens where you can explore different UI techniques and graphics rendering approaches.
 
 <a href="https://apps.apple.com/app/id6743644224" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 250px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&h=b17e195bc020808628890cbe7fcde25f" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
+
+> 📎 [Try it instantly with App Clip (iOS only)](https://appclip.apple.com/id?p=com.takehito.koshimizu.MyToybox.MyToyboxClip)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Documentation across `CLAUDE.md`, both READMEs, four slash-command files, `LOCALIZATION_WORKFLOW.md`, and both `AppClip-Runbook` files had drifted from the actual module layout introduced in PR #153 — specifically, the catalog rename from `MyToyboxCatalog`/`MyToyboxClipCatalog` to `AppScreens`/`ClipScreens`, the removal of the `MyToyboxUI` module (whose contents moved to `Screens/RootScreen/` and `MyToyboxCore`), and the addition of `MockScreens` and `PlatformSupport`. This PR corrects all 16 stale references, aligns the simulator OS version in `CLAUDE.md` with the CI configuration (`26.4.1` → `26.4`), and adds App Store and App Clip entry points to both READMEs.

## Changes

- **Module name corrections** (10 files): Replace `MyToyboxCatalog/Screen.swift` → `AppScreens/AppScreen.swift`, `MyToyboxClipCatalog` → `ClipScreens`, and remove all `MyToyboxUI` references. `DeepLinkSheet` is now attributed to `MyToyboxCore`; `RootScreen`/`DetailScreen` paths updated to `Screens/RootScreen/` and `Screens/DetailScreen/`.
- **Module structure additions** (`CLAUDE.md`, `README.md`, `README.ja.md`): Add previously undocumented modules — `MockScreens`, `PlatformSupport`, `MyToyboxMedia`, `Screens/DetailScreen/` — to the module list and directory tree.
- **Slash commands** (`.claude/commands/new-screen.md`, `validate-screens.md`, `sync-docs.md`): Update all path and enum-name references from `MyToyboxCatalog/Screen.swift` / `enum Screen` to `AppScreens/AppScreen.swift` / `enum AppScreen` so commands operate on the correct file.
- **`LOCALIZATION_WORKFLOW.md`**: Remove the non-existent `MyToyboxUI/Resources/Localizable.xcstrings` entry; update the `app.*` key ownership comment to `MyToyboxCore` only.
- **`Docs/AppClip-Runbook.md` / `.ja.md`**: Correct the internal-visibility note from `Screen` in `MyToyboxCatalog` to `AppScreen` in `AppScreens`.
- **`CLAUDE.md` build commands**: Fix simulator destination from `OS=26.4.1` to `OS=26.4` to match the CI workflow.
- **App Store badge** (`README.md`, `README.ja.md`): Add `Download on the App Store` HTML badge linked to `https://apps.apple.com/app/id6743644224`.
- **App Clip links** (`README.md`, `README.ja.md`): Add a shields.io `App Clip` badge in the header badge row and a blockquote text link below the App Store badge, both pointing to `https://appclip.apple.com/id?p=com.takehito.koshimizu.MyToybox.MyToyboxClip`.

## Motivation & Context

- The module layout was restructured in PR #153 but documentation was not updated at the same time, leaving stale paths throughout all doc files. Claude Code slash commands that reference `MyToyboxCatalog/Screen.swift` would fail to read the correct file.
- The `OS=26.4.1` mismatch between `CLAUDE.md` and `ci.yml` could cause local builds to silently target a different simulator runtime than CI.
- The App Store and App Clip badges surface distribution channels directly from the repository landing page, matching the convention already established in the TicTacToe repository.

