### PR TITLE
Fix macOS build support for representable screen

### DIFF
--- a/App/MyToybox.xcodeproj/project.pbxproj
+++ b/App/MyToybox.xcodeproj/project.pbxproj
@@ -12,7 +12,14 @@
 		3AFB23ED2FAEEC4600C78D45 /* RootScreen in Frameworks */ = {isa = PBXBuildFile; productRef = 3AFB23EC2FAEEC4600C78D45 /* RootScreen */; };
 		3AFB23EF2FAEEC4F00C78D45 /* RootScreen in Frameworks */ = {isa = PBXBuildFile; productRef = 3AFB23EE2FAEEC4F00C78D45 /* RootScreen */; };
 		AABB00012FAB000100000001 /* TagPicker in Frameworks */ = {isa = PBXBuildFile; productRef = AABB00002FAB000100000001 /* TagPicker */; };
-		AABB00042FAB000100000001 /* MyToyboxClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 7B40C1F22F0A100100A0A001 /* MyToyboxClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AABB00042FAB000100000001 /* MyToyboxClip.app in Embed App Clips */ = {
+			isa = PBXBuildFile;
+			fileRef = 7B40C1F22F0A100100A0A001 /* MyToyboxClip.app */;
+			platformFilters = (
+				ios,
+			);
+			settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); };
+		};
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -613,6 +613,14 @@ let package = Package(
             resources: [.process("Resources")]
         ),
         .target(
+            name: "Screen_ViewcontrollerRepresentable_macOS",
+            dependencies: [
+                "MyToyboxCore",
+            ],
+            path: "Sources/Screens/ViewcontrollerRepresentable_macOS",
+            resources: [.process("Resources")]
+        ),
+        .target(
             name: "Screen_Visualeffect",
             dependencies: ["MyToyboxCore"],
             path: "Sources/Screens/Visualeffect",
@@ -753,7 +761,8 @@ let package = Package(
                 "Screen_TileAnimation3D",
                 "Screen_UnevenRoundedRectangle1",
                 "Screen_UnevenRoundedRectangle2",
-                "Screen_ViewcontrollerRepresentable",
+                .target(name: "Screen_ViewcontrollerRepresentable", condition: .when(platforms: [.iOS])),
+                .target(name: "Screen_ViewcontrollerRepresentable_macOS", condition: .when(platforms: [.macOS])),
                 "Screen_Visualeffect",
                 "Screen_VoronoiDiagram",
                 "Screen_WaveCircle",
@@ -783,5 +792,11 @@ let package = Package(
 
 // Xcode Previews requires each target to be a library product.
 package.products += package.targets
-    .filter { $0.name.hasPrefix("Screen_") }
+    .filter {
+        $0.name.hasPrefix("Screen_")
+            && ![
+                "Screen_ViewcontrollerRepresentable",
+                "Screen_ViewcontrollerRepresentable_macOS",
+            ].contains($0.name)
+    }
     .map { .library(name: $0.name, targets: [$0.name]) }

--- a/Packages/Sources/AppScreens/AppScreen.swift
+++ b/Packages/Sources/AppScreens/AppScreen.swift
@@ -80,7 +80,11 @@ import Screen_TileAnimation
 import Screen_TileAnimation3D
 import Screen_UnevenRoundedRectangle1
 import Screen_UnevenRoundedRectangle2
+#if os(iOS)
 import Screen_ViewcontrollerRepresentable
+#elseif os(macOS)
+import Screen_ViewcontrollerRepresentable_macOS
+#endif
 import Screen_Visualeffect
 import Screen_VoronoiDiagram
 import Screen_WaveCircle

--- a/Packages/Sources/MyToyboxCore/View+BackgroundExtension.swift
+++ b/Packages/Sources/MyToyboxCore/View+BackgroundExtension.swift
@@ -4,7 +4,7 @@ public extension View {
     @ViewBuilder
     @_disfavoredOverload
     func backgroundExtensionEffect() -> some View {
-        if #available(iOS 26.0, *) {
+        if #available(iOS 26.0, macOS 26.0, *) {
             self.SwiftUI::backgroundExtensionEffect()
         } else {
             ignoresSafeArea()

--- a/Packages/Sources/Screens/DetailScreen/DetailScreen.swift
+++ b/Packages/Sources/Screens/DetailScreen/DetailScreen.swift
@@ -26,7 +26,9 @@ public struct DetailScreen<Screen: MyToyboxScreen>: View {
                     .navigationTitle(.appTitle)
             }
         }
+        #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
+        #endif
     }
 }
 

--- a/Packages/Sources/Screens/RootScreen/Components/RootSidebarView.swift
+++ b/Packages/Sources/Screens/RootScreen/Components/RootSidebarView.swift
@@ -58,7 +58,9 @@ private extension RootSidebarView {
             List(screens, id: \.self) { screen in
                 NavigationLink {
                     DetailScreen(screen: screen)
+                        #if os(iOS)
                         .navigationTransition(.zoom(sourceID: screen, in: namespace))
+                        #endif
                 } label: {
                     RootCell(screen: screen, isScrolling: isScrolling, namespace: namespace)
                 }

--- a/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/Resources/Localizable.xcstrings
+++ b/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/Resources/Localizable.xcstrings
@@ -1,0 +1,40 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "screen.viewControllerRepresentable.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hosted AppKit content loaded from a macOS XIB"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppKit の画面を XIB から読み込み、SwiftUI に埋め込む"
+          }
+        }
+      }
+    },
+    "screen.viewControllerRepresentable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NSViewControllerRepresentable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppKit連携（Representable）"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/Resources/SampleViewController.xib
+++ b/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/Resources/SampleViewController.xib
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="SampleViewController" customModule="Screen_ViewcontrollerRepresentable_macOS" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="mainView" id="outlet-view"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="mainView">
+            <rect key="frame" x="0.0" y="0.0" width="300" height="120"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="750" editable="NO" bezeled="NO" drawsBackground="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="titleLabel">
+                    <rect key="frame" x="80" y="60" width="140" height="25"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Hello, world!" id="titleCell">
+                        <font key="font" metaFont="systemBold" size="20"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="750" editable="NO" bezeled="NO" drawsBackground="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="subtitleLabel">
+                    <rect key="frame" x="80" y="30" width="140" height="20"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Hello, world!" id="subtitleCell">
+                        <font key="font" metaFont="system" size="14"/>
+                        <color key="textColor" name="controlAccentColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <constraints>
+                <constraint firstItem="titleLabel" firstAttribute="centerX" secondItem="mainView" secondAttribute="centerX" id="cx-title"/>
+                <constraint firstItem="subtitleLabel" firstAttribute="centerX" secondItem="mainView" secondAttribute="centerX" id="cx-subtitle"/>
+                <constraint firstItem="titleLabel" firstAttribute="centerY" secondItem="mainView" secondAttribute="centerY" constant="10" id="cy-title"/>
+                <constraint firstItem="subtitleLabel" firstAttribute="top" secondItem="titleLabel" secondAttribute="bottom" constant="-8" id="top-subtitle"/>
+            </constraints>
+        </customView>
+    </objects>
+</document>

--- a/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/SampleViewController.swift
+++ b/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/SampleViewController.swift
@@ -1,0 +1,9 @@
+#if os(macOS)
+import AppKit
+
+final class SampleViewController: NSViewController {
+    convenience init() {
+        self.init(nibName: String(describing: Self.self), bundle: .module)
+    }
+}
+#endif

--- a/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/ViewcontrollerRepresentableScreen+Thumbnail.swift
+++ b/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/ViewcontrollerRepresentableScreen+Thumbnail.swift
@@ -1,0 +1,20 @@
+import MyToyboxCore
+import SwiftUI
+
+public extension ViewcontrollerRepresentableScreen {
+    @ViewBuilder
+    static func thumbnail(isScrolling _: Bool, time _: TimeInterval) -> some View {
+        GeometryReader { geometry in
+            Image(systemName: "pencil.and.ruler.fill")
+                .resizable()
+                .scaledToFit()
+                .padding(2 * geometry.size.width / 10)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.orange.gradient)
+        }
+    }
+}
+
+#Preview {
+    ViewcontrollerRepresentableScreen.thumbnail
+}

--- a/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/ViewcontrollerRepresentableScreen.swift
+++ b/Packages/Sources/Screens/ViewcontrollerRepresentable_macOS/ViewcontrollerRepresentableScreen.swift
@@ -1,0 +1,58 @@
+import MyToyboxCore
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+// MARK: - ViewControllerRepresentableScreen
+
+/// A SwiftUI screen that demonstrates the integration of an AppKit NSViewController
+/// using NSViewControllerRepresentable, loading its view hierarchy from a macOS XIB.
+@Metadata(title: .screenViewControllerRepresentableTitle, description: .screenViewControllerRepresentableDescription, tags: [.layout])
+public struct ViewcontrollerRepresentableScreen: View {
+    public init() {}
+
+    public var body: some View {
+        VStack {
+            ViewControllerRepresentable(SampleViewController())
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.blue.opacity(0.1))
+                .clipShape(.rect(cornerRadius: 10))
+                .padding()
+        }
+    }
+}
+
+// MARK: - ViewControllerRepresentable
+
+private struct ViewControllerRepresentable<ViewController: NSViewController>: NSViewControllerRepresentable {
+    private let viewController: () -> ViewController
+
+    init(_ viewController: @autoclosure @escaping () -> ViewController) {
+        self.viewController = viewController
+    }
+
+    func makeNSViewController(context _: Context) -> ViewController {
+        viewController()
+    }
+
+    func updateNSViewController(_: ViewController, context _: Context) {}
+}
+
+// MARK: - Preview
+
+#Preview {
+    ViewcontrollerRepresentableScreen()
+}
+
+#elseif os(iOS)
+@Metadata(title: .screenViewControllerRepresentableTitle, description: .screenViewControllerRepresentableDescription, tags: [.layout])
+public struct ViewcontrollerRepresentableScreen: View {
+    public init() {}
+
+    public var body: some View {
+        Text(verbatim: "This module is for macOS")
+            .foregroundStyle(.secondary)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add a macOS AppKit/XIB variant for the ViewcontrollerRepresentable screen while keeping the existing iOS UIKit/XIB implementation.
- Wire AppScreens to use platform-specific screen targets and prevent the iOS App Clip from being embedded in macOS builds.
- Guard iOS-only SwiftUI APIs so the macOS MyToybox build succeeds.
